### PR TITLE
Add bash autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ $ wget raw.githubusercontent.com/qzb/is.sh/latest/is.sh
 $ source ./is.sh
 ```
 
+If you have installed is.sh, you can use bash autocompletion with it. Simply
+download the completion file to `/etc/bash_completion.d/`:
+
+```sh
+$ sudo sh -c 'cd /etc/bash_completion.d && wget raw.githubusercontent.com/qzb/is.sh/latest/completion/is-completion.bash -O is'
+```
+
 ## Usage
 
 ### Conditions

--- a/completion/is-completion.bash
+++ b/completion/is-completion.bash
@@ -1,0 +1,25 @@
+#
+# Bash completion definition for is.
+#
+_is () {
+    local cur prev not articles opts
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    not=" not "
+    articles=" a an the "
+    opts=" file dir directory link symlink existing readable writeable "
+    opts+="executable available installed empty number older newer "
+    opts+="gt lt ge le equal matching substring true false "
+
+    if is substring " ${prev} " "${opts}"; then
+        COMPREPLY=()
+    elif is substring " ${prev} " "${articles}"; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    elif is substring " ${prev} " "${not}"; then
+        COMPREPLY=( $(compgen -W "${articles}${opts}" -- ${cur}) )
+    else
+        COMPREPLY=( $(compgen -W "${not}${articles}${opts}" -- ${cur}) )
+    fi
+    return 0
+}
+complete -F _is is


### PR DESCRIPTION
I added a bash autocompletion definition file to allow for
```sh
$ is a[TAB]
a          an         available

$ is not an e[TAB]
empty       equal       executable  existing
```

I also added a short description for global installation to the README. Do you think we should add a description for local installation as well (storing the file somewhere under `$HOME` and sourcing it in `.bashrc`)?

If you would like to include it with npm, we could have a look at [npm shell completion](https://www.npmjs.com/package/shell-completion).