### PR TITLE
Add broken condition

### DIFF
--- a/is.sh
+++ b/is.sh
@@ -28,6 +28,8 @@ Conditions:
   is writeable PATH
   is executable PATH
   is available COMMAND
+  is installed COMMAND
+  is broken COMMAND
   is older PATH_A PATH_B
   is newer PATH_A PATH_B
   is true VALUE
@@ -65,6 +67,10 @@ EOF
         return $?
     fi
 
+    if [ "$condition" == "broken" ]; then
+        shift 1
+    fi
+
     case "$condition" in
         file)
             [ -f "$value_a" ]; return $?;;
@@ -82,6 +88,8 @@ EOF
             [ -x "$value_a" ]; return $?;;
         available|installed)
             which "$value_a"; return $?;;
+        broken)
+            eval "${@}" >/dev/null 2>&1; [ "$?" != 0 ]; return $?;;
         empty)
             [ -z "$value_a" ]; return $?;;
         number)

--- a/is.sh
+++ b/is.sh
@@ -51,9 +51,9 @@ EOF
         exit
     fi
 
-    local condition="$1"
-    local value_a="$2"
-    local value_b="$3"
+    local condition="${1:-}"
+    local value_a="${2:-}"
+    local value_b="${3:-}"
 
     if [ "$condition" == "not" ]; then
         shift 1

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -95,6 +95,12 @@ assert_false "$is executable ./forbidden_file"
 assert_true  "$is available which"
 assert_false "$is available witch"
 
+# is broken
+assert_true "$is broken cat foobar"
+assert_false "$is broken cat file"
+assert_true "$is not broken ln --help"
+assert_false "$is broken ln --help"
+
 # is empty
 assert_true  "$is empty"
 assert_true  "$is empty ''"


### PR DESCRIPTION
In some scripts, I just want to check that the return code of some command is falsey.  This adds `is broken [cmd ...]` to allow easy checking for that.