### PR TITLE
Features, Maintainability, & Style changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# For more information about the properties used in this file, please see the
+# EditorConfig documentation:
+# https://editorconfig.org/
+
+# top-most EditorConfig file
+root = true
+
+# editorconfig-tools is unable to ignore longs strings or urls
+max_line_length = null
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Markdown uses the trailing whitespaces
+# https://daringfireball.net/projects/markdown/syntax#block
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: bash
 os:
-    - linux
-    - osx
+  - linux
+  - osx
 script:
-    - ./tests/tests.sh
+  - ./tests/tests.sh

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Józef Sokołowski
+Copyright (c) 2015-2019 Józef Sokołowski
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ checks if...
 * `is newer "$pathA" "$pathB"` - 1st path is newer than the 2nd
 * `is true "$value"` - value is equal to `true` or `0`
 * `is false "$value"` - value is not equal to `true` and not equal to `0`
+* `is alias name` - name is an alias
+* `is builtin name` - name is a builtin
+* `is function name` - name is a function
+* `is keyword name` - name is a keyword
+* `is in "$value" arrayName` - value is in the array
 
 ### Negations
 
@@ -93,6 +98,10 @@ $ is a number 5; printf '%s\n' $?
 $ is not a substring abc defghi; printf '%s\n' $?
 1
 ```
+
+### Examples
+
+See the [tests](./tests/tests.sh) file for examples.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@ Fancy alternative for old good test command.
 ## Example
 
 ```sh
-var=123
+declare var=123
 
-if is equal $var 123.0; then
-    echo "it just works"
-fi
+$ is equal "$var" 123.0 && printf 'it just works!\n'
+it just works
 
-if is not a substring $var "foobar"; then
-    echo "and it's easy to read"
-fi
+$ is not a substring "$var" 'foobar' && printf "and it is easy to read\n"
+and it is easy to read
 ```
 
 ## Installation
@@ -25,52 +23,63 @@ In order to use is.sh you can install it with one of following 1-liners:
 
 ```sh
 # Unix-like
-$ sudo sh -c 'cd /usr/local/bin && wget raw.githubusercontent.com/qzb/is.sh/latest/is.sh -O is && chmod +x is'
+$ sudo sh -c 'cd /usr/local/bin \
+  && wget raw.githubusercontent.com/qzb/is.sh/latest/is.sh -O is \
+  && chmod +x is'
 
 # NPM
 $ npm install -g is.sh
 ```
 
-If you don't want to install is.sh system-wide you can just download it and source it from your script:
+If you don't want to install is.sh system-wide you can just download it and
+  source it from your script:
 
 ```sh
-$ wget raw.githubusercontent.com/qzb/is.sh/latest/is.sh
-$ source ./is.sh
+# retrieve and source
+$ wget raw.githubusercontent.com/qzb/is.sh/latest/is.sh && . ./is.sh
+
 ```
 
 ## Usage
 
+* `is` without arguments will print out version followed by usage
+* `is --help` - displays usage
+* `is --version` - displays version
+
 ### Conditions
 
-* ``is equal $valueA $valueB`` - checks if values are the same or if they are equal numbers
-* ``is matching $regexp $value`` - checks if whole value matches to regular expression
-* ``is substring $valueA $valueB`` - checks if first value is a part of second one
-* ``is empty $value`` - checks if value is empty
-* ``is number $value`` - checks if value is a number
-* ``is gt $numberA $numberB`` - true if first number is greater than second one
-* ``is lt $numberA $numberB`` - true if first number is less than second one
-* ``is ge $numberA $numberB`` - true if first number is greater than or equal to second one
-* ``is le $numberA $numberB`` - true if first number is less than or equal to second one
-* ``is file $path`` - checks if it is a file
-* ``is dir $path`` - checks if it is a directory
-* ``is link $path`` - checks if it is a symbolic link
-* ``is existent $path`` - checks if there is a file or directory or anything else with this path
-* ``is readable $path`` - checks if file is readable
-* ``is writeable $path`` - checks if file is writeable
-* ``is executable $path`` - checks if file is executable
-* ``is available $command`` - checks if given command is available
-* ``is older $pathA $pathB`` - checks if first file is older than second one
-* ``is newer $pathA $pathB`` - checks if first file is newer than second one
-* ``is true $value`` - true if value is equal "true" or "0"
-* ``is false $value`` - opposite of ``is true $value``
+checks if...
+
+* `is equal "$valueA" "$valueB"` - 1st value is identical||equivalent to the 2nd
+* `is matching "$regex" "$value"` - whole value matches the regular expression
+* `is substring "$valueA" "$valueB"` - 1st value is a part of the 2nd
+* `is empty "$value"` - value is empty
+* `is number "$value"` - value is a number
+* `is gt "$numberA" "$numberB"` - 1st number is greater than the 2nd
+* `is lt "$numberA" "$numberB"` - 1st number is less than the 2nd
+* `is ge "$numberA" "$numberB"` - 1st number is greater than or equal to the 2nd
+* `is le "$numberA" "$numberB"` - 1st number is less than or equal to the 2nd
+* `is file "$path"` - path is a file
+* `is dir "$path"` - path is a directory
+* `is link "$path"` - path is a symbolic link
+* `is existent "$path"` - there is anything at this path
+* `is readable "$path"` - path is readable
+* `is writeable "$path"` - path is writeable
+* `is executable "$path"` - path is executable
+* `is available "$command"` - command is available
+* `is older "$pathA" "$pathB"` - 1st path is older than the 2nd
+* `is newer "$pathA" "$pathB"` - 1st path is newer than the 2nd
+* `is true "$value"` - value is equal to `true` or `0`
+* `is false "$value"` - value is not equal to `true` and not equal to `0`
 
 ### Negations
 
 You can negate any condition by putting *not* in front of it.
 
 ```sh
-$ is number "abc" && echo "number"
-$ is not number "abc" && echo "not a number"
+$ is number '123' && printf 'number'
+number
+$ is not number 'abc' && printf 'not a number'
 not a number
 ```
 
@@ -79,14 +88,15 @@ not a number
 You can add *a*, *an*, and *the* articles before condition name.
 
 ```sh
-$ is a number 5
-$ is not a substring abc defghi
+$ is a number 5; printf '%s\n' $?
+0
+$ is not a substring abc defghi; printf '%s\n' $?
+1
 ```
 
 ## License
 
 MIT
-
 
 [npm-image]: https://img.shields.io/npm/v/is.sh.svg
 [npm-url]: https://npmjs.org/package/is.sh

--- a/README.md
+++ b/README.md
@@ -51,30 +51,53 @@ $ wget raw.githubusercontent.com/qzb/is.sh/latest/is.sh && . ./is.sh
 checks if...
 
 * `is equal "$valueA" "$valueB"` - 1st value is identical||equivalent to the 2nd
+  * alternate(s) `eq`
 * `is matching "$regex" "$value"` - whole value matches the regular expression
+  * alternate(s) `match`
 * `is substring "$valueA" "$valueB"` - 1st value is a part of the 2nd
+  * alternate(s) `substr`
 * `is empty "$value"` - value is empty
 * `is number "$value"` - value is a number
+  * alternate(s) `num`
 * `is gt "$numberA" "$numberB"` - 1st number is greater than the 2nd
 * `is lt "$numberA" "$numberB"` - 1st number is less than the 2nd
 * `is ge "$numberA" "$numberB"` - 1st number is greater than or equal to the 2nd
 * `is le "$numberA" "$numberB"` - 1st number is less than or equal to the 2nd
 * `is file "$path"` - path is a file
 * `is dir "$path"` - path is a directory
+  * alternate(s) `directory`
 * `is link "$path"` - path is a symbolic link
+  * alternate(s) `symlink`
 * `is existent "$path"` - there is anything at this path
+  * alternate(s) `exists`, `exist`, `existing`
 * `is readable "$path"` - path is readable
 * `is writeable "$path"` - path is writeable
 * `is executable "$path"` - path is executable
-* `is available "$command"` - command is available
+* `is available "$command"` - command is available (using `which`)
+  * alternate(s) `installed`
+* `is cmd "$command"` - command is available (using `command`)
+  * alternate(s) `command`
 * `is older "$pathA" "$pathB"` - 1st path is older than the 2nd
 * `is newer "$pathA" "$pathB"` - 1st path is newer than the 2nd
 * `is true "$value"` - value is equal to `true` or `0`
 * `is false "$value"` - value is not equal to `true` and not equal to `0`
-* `is alias name` - name is an alias
-* `is builtin name` - name is a builtin
-* `is function name` - name is a function
-* `is keyword name` - name is a keyword
+* `is truthy "$value"` - value is equal to `0|t|y|true|yes|on` (case-insensitive)
+* `is falsey "$value"` - value is equal to `1|f|n|false|no|off` (case-insensitive)
+* `is boolean NAME` - name is an variable, name is either `truthy` or `falsey`
+  * alternate(s) `bool`
+* `is alias NAME` - name is an alias
+* `is builtin NAME` - name is a builtin
+* `is function NAME` - name is a function
+  * alternate(s) `fn`
+* `is keyword NAME` - name is a keyword
+* `is array NAME` - name is a variable
+* `is hash NAME` - name is a variable
+  * alternate(s) `dictionary`
+* `is integer NAME` - name is a variable
+* `is exported NAME` - name is a variable
+  * alternate(s) `export`
+* `is set NAME` - name is a variable
+  * alternate(s) `var`, `variable`
 * `is in "$value" arrayName` - value is in the array
 
 ### Negations

--- a/is.sh
+++ b/is.sh
@@ -126,7 +126,7 @@ is() {
       [ "$1" == true ] || [ "$1" == 0 ]; return $?;;
     false)
       [ "$1" != true ] && [ "$1" != 0 ]; return $?;;
-  esac > /dev/null
+  esac 1> /dev/null
 
   return 1
 }

--- a/is.sh
+++ b/is.sh
@@ -49,8 +49,6 @@ EOF
     fi
 
   local condition="$1" && shift 1
-  local value_a="$1"
-  local value_b="$2"
 
   if [ "$condition" = 'not' ]; then
         ! is "${@}"
@@ -67,58 +65,58 @@ EOF
   #       it is being kept for consistency
     case "$condition" in
         file)
-            [ -f "$value_a" ]; return $?;;
+            [ -f "$1" ]; return $?;;
         dir|directory)
-            [ -d "$value_a" ]; return $?;;
+            [ -d "$1" ]; return $?;;
         link|symlink)
-            [ -L "$value_a" ]; return $?;;
+            [ -L "$1" ]; return $?;;
         existent|existing|exist|exists)
-            [ -e "$value_a" ]; return $?;;
+            [ -e "$1" ]; return $?;;
         readable)
-            [ -r "$value_a" ]; return $?;;
+            [ -r "$1" ]; return $?;;
         writeable)
-            [ -w "$value_a" ]; return $?;;
+            [ -w "$1" ]; return $?;;
         executable)
-            [ -x "$value_a" ]; return $?;;
+            [ -x "$1" ]; return $?;;
         available|installed)
-            which "$value_a"; return $?;;
+            which "$1"; return $?;;
         empty)
-            [ -z "$value_a" ]; return $?;;
+            [ -z "$1" ]; return $?;;
         number)
-            echo "$value_a" | grep -E '^[0-9]+(\.[0-9]+)?$'; return $?;;
+            echo "$1" | grep -E '^[0-9]+(\.[0-9]+)?$'; return $?;;
         older)
-            [ "$value_a" -ot "$value_b" ]; return $?;;
+            [ "$1" -ot "$2" ]; return $?;;
         newer)
-            [ "$value_a" -nt "$value_b" ]; return $?;;
+            [ "$1" -nt "$2" ]; return $?;;
         gt)
-            is not a number "$value_a"      && return 1;
-            is not a number "$value_b"      && return 1;
-            awk "BEGIN {exit $value_a > $value_b ? 0 : 1}"; return $?;;
+            is not a number "$1"      && return 1;
+            is not a number "$2"      && return 1;
+            awk "BEGIN {exit $1 > $2 ? 0 : 1}"; return $?;;
         lt)
-            is not a number "$value_a"      && return 1;
-            is not a number "$value_b"      && return 1;
-            awk "BEGIN {exit $value_a < $value_b ? 0 : 1}"; return $?;;
+            is not a number "$1"      && return 1;
+            is not a number "$2"      && return 1;
+            awk "BEGIN {exit $1 < $2 ? 0 : 1}"; return $?;;
         ge)
-            is not a number "$value_a"      && return 1;
-            is not a number "$value_b"      && return 1;
-            awk "BEGIN {exit $value_a >= $value_b ? 0 : 1}"; return $?;;
+            is not a number "$1"      && return 1;
+            is not a number "$2"      && return 1;
+            awk "BEGIN {exit $1 >= $2 ? 0 : 1}"; return $?;;
         le)
-            is not a number "$value_a"      && return 1;
-            is not a number "$value_b"      && return 1;
-            awk "BEGIN {exit $value_a <= $value_b ? 0 : 1}"; return $?;;
+            is not a number "$1"      && return 1;
+            is not a number "$2"      && return 1;
+            awk "BEGIN {exit $1 <= $2 ? 0 : 1}"; return $?;;
         eq|equal)
-            [ "$value_a" = "$value_b" ]     && return 0;
-            is not a number "$value_a"      && return 1;
-            is not a number "$value_b"      && return 1;
-            awk "BEGIN {exit $value_a == $value_b ? 0 : 1}"; return $?;;
+            [ "$1" = "$2" ]     && return 0;
+            is not a number "$1"      && return 1;
+            is not a number "$2"      && return 1;
+            awk "BEGIN {exit $1 == $2 ? 0 : 1}"; return $?;;
         match|matching)
-            echo "$value_b" | grep -xE "$value_a"; return $?;;
+            echo "$2" | grep -xE "$1"; return $?;;
         substr|substring)
-            echo "$value_b" | grep -F "$value_a"; return $?;;
+            echo "$2" | grep -F "$1"; return $?;;
         true)
-            [ "$value_a" == true ] || [ "$value_a" == 0 ]; return $?;;
+            [ "$1" == true ] || [ "$1" == 0 ]; return $?;;
         false)
-            [ "$value_a" != true ] && [ "$value_a" != 0 ]; return $?;;
+            [ "$1" != true ] && [ "$1" != 0 ]; return $?;;
     esac > /dev/null
 
     return 1

--- a/is.sh
+++ b/is.sh
@@ -77,13 +77,23 @@ is() {
     command unset ${BASH_VERSION:+-f}
   }
 
+  is::tolower() {
+    if [ "$IS_NOT_OLD_BASH" -eq 0 ]; then
+      printf '%s' "${1,,}"
+    else
+      printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+    fi
+
+    return 0
+  }
+
   [ "$#" -eq 0 ] && is::show.version && is::show.help && return 0
   [ "$1" = '--help' ] && is::show.help && return 0
   [ "$1" = '--version' ] && is::show.version && return 0
 
   # Since we currently support bash v3.2.57, we can't use `"${1,,}"`
   local condition=$1 && shift 1
-  condition="$(printf '%s' "${condition}" | tr '[:upper:]' '[:lower:]')"
+  condition=$(is::tolower "$condition")
 
   if [ "$condition" = 'not' ]; then
     ! is "${@}"
@@ -92,7 +102,7 @@ is() {
 
   while [ "$condition" == 'a' ] || [ "$condition" == 'an' ] \
     || [ "$condition" == 'the' ]; do :
-    condition=$1 && shift 1
+    condition=$(is::tolower "$1") && shift 1
   done
 
   # Note: case statements takes an expression & therefore doesn't need quotes
@@ -151,10 +161,10 @@ is() {
     bool|boolean)
       is 'truthy' "$1" || is 'falsey' "$1" || return 2;;
     truthy)
-      case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+      case $(is::tolower "$1") in
         0|t|y|true|yes|on) true;; *) false;; esac;;
     falsey)
-      case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+      case $(is::tolower "$1") in
         1|f|n|false|no|off) true;; *) false;; esac;;
     set|var|variable)
       # cross-sh-compatible sans `pdksh v5.2.14` treats expanded empty as unset

--- a/is.sh
+++ b/is.sh
@@ -7,7 +7,7 @@
 ##
 
 is() {
-  local name="${FUNCNAME[0]}" version='1.1.2'
+  local name="${FUNCNAME[0]}" version='1.2.0'
   declare IS_NOT_OLD_BASH # so > bash 3
   [ "${BASH_VERSINFO[0]}" -ge 4 ] && IS_NOT_OLD_BASH=0 || IS_NOT_OLD_BASH=1
 

--- a/is.sh
+++ b/is.sh
@@ -48,19 +48,17 @@ EOF
         exit
     fi
 
-    local condition="$1"
-    local value_a="$2"
-    local value_b="$3"
+  local condition="$1" && shift 1
+  local value_a="$1"
+  local value_b="$2"
 
   if [ "$condition" = 'not' ]; then
-    shift 1
         ! is "${@}"
         return $?
     fi
 
   if [ "$condition" == 'a' ] || [ "$condition" == 'an' ] \
     || [ "$condition" == 'the' ]; then
-        shift 1
         is "${@}"
         return $?
     fi

--- a/is.sh
+++ b/is.sh
@@ -58,7 +58,8 @@ EOF
         return $?
     fi
 
-    if [ "$condition" == "a" ] || [ "$condition" == "an" ] || [ "$condition" == "the" ]; then
+  if [ "$condition" == "a" ] || [ "$condition" == "an" ] \
+    || [ "$condition" == "the" ]; then
         shift 1
         is "${@}"
         return $?

--- a/is.sh
+++ b/is.sh
@@ -98,8 +98,9 @@ is() {
     empty)
       [ -z "$1" ];;
     number)
-      printf '%s' "$1" \
-        | grep -E '^[-+]?([0-9]+\.?|[0-9]*\.[0-9]+)$' 1> /dev/null;;
+      # for compatibility w/ versions < 3.2, regex must be stored in variable
+      local regex='^[-+]?([0-9]+\.?|[0-9]*\.[0-9]+)$'
+      [[ $1 = *[0-9]* && $1 =~ $regex ]];;
     older)
       [ "$1" -ot "$2" ];;
     newer)

--- a/is.sh
+++ b/is.sh
@@ -50,13 +50,8 @@ is() {
     exit 0
   }
 
-  if [ "$1" == '--help' ]; then
-    is::show.help
-  fi
-
-  if [ "$1" == '--version' ]; then
-    is::show.version
-  fi
+  [ "$1" = '--help' ] && is::show.help
+  [ "$1" = '--version' ] && is::show.version
 
   local condition="$1" && shift 1
 

--- a/is.sh
+++ b/is.sh
@@ -7,7 +7,7 @@
 ##
 
 is() {
-  local name="${FUNCNAME[0]}" version='1.1.0'
+  local name="${FUNCNAME[0]}" version='1.1.2'
 
   is::show.help() {
     command printf 'Conditions:\n'

--- a/is.sh
+++ b/is.sh
@@ -7,7 +7,7 @@
 ##
 
 is() {
-    if [ "$1" == "--help" ]; then
+    if [ "$1" == '--help' ]; then
         cat << EOF
 Conditions:
   is equal VALUE_A VALUE_B
@@ -43,7 +43,7 @@ EOF
         exit
     fi
 
-    if [ "$1" == "--version" ]; then
+    if [ "$1" == '--version' ]; then
         echo "is.sh 1.1.0"
         exit
     fi
@@ -52,14 +52,14 @@ EOF
     local value_a="$2"
     local value_b="$3"
 
-    if [ "$condition" == "not" ]; then
-        shift 1
+  if [ "$condition" = 'not' ]; then
+    shift 1
         ! is "${@}"
         return $?
     fi
 
-  if [ "$condition" == "a" ] || [ "$condition" == "an" ] \
-    || [ "$condition" == "the" ]; then
+  if [ "$condition" == 'a' ] || [ "$condition" == 'an' ] \
+    || [ "$condition" == 'the' ]; then
         shift 1
         is "${@}"
         return $?

--- a/is.sh
+++ b/is.sh
@@ -121,7 +121,7 @@ is() {
     num|number)
       # for compatibility w/ versions < 3.2, regex must be stored in variable
       local regex='^[-+]?([0-9]+\.?|[0-9]*\.[0-9]+)$'
-      [[ $1 = *[0-9]* && $1 =~ $regex ]];;
+      [[ $1 = *[0-9]* && $1 =~ $regex ]] || is 'int' "$1";;
     older)
       [ "$1" -ot "$2" ];;
     newer)

--- a/is.sh
+++ b/is.sh
@@ -10,38 +10,39 @@ is() {
   local name="${FUNCNAME[0]}" version='1.1.0'
 
   is::show.help() {
-    cat <<- EOF
-			Conditions:
-			  is equal VALUE_A VALUE_B
-			  is matching REGEXP VALUE
-			  is substring VALUE_A VALUE_B
-			  is empty VALUE
-			  is number VALUE
-			  is gt NUMBER_A NUMBER_B
-			  is lt NUMBER_A NUMBER_B
-			  is ge NUMBER_A NUMBER_B
-			  is le NUMBER_A NUMBER_B
-			  is file PATH
-			  is dir PATH
-			  is link PATH
-			  is existing PATH
-			  is readable PATH
-			  is writeable PATH
-			  is executable PATH
-			  is available COMMAND
-			  is older PATH_A PATH_B
-			  is newer PATH_A PATH_B
-			  is true VALUE
-			  is false VALUE
+    printf 'Conditions:\n'
+    printf "  ${name} %s\n" \
+      'equal VALUE_A VALUE_B' \
+      'matching REGEXP VALUE' \
+      'substring VALUE_A VALUE_B' \
+      'empty VALUE' \
+      'number VALUE' \
+      'gt NUMBER_A NUMBER_B' \
+      'lt NUMBER_A NUMBER_B' \
+      'ge NUMBER_A NUMBER_B' \
+      'le NUMBER_A NUMBER_B' \
+      'file PATH' \
+      'dir PATH' \
+      'link PATH' \
+      'existing PATH' \
+      'readable PATH' \
+      'writeable PATH' \
+      'executable PATH' \
+      'available COMMAND' \
+      'older PATH_A PATH_B' \
+      'newer PATH_A PATH_B' \
+      'true VALUE' \
+      'false VALUE'
 
-			Negation:
-			  is not equal VALUE_A VALUE_B
+    printf '\nNegation:\n'
+    printf "  ${name} %s\n" \
+      'not equal VALUE_A VALUE_B'
 
-			Optional article:
-			  is not a number VALUE
-			  is an existing PATH
-			  is the file PATH
-		EOF
+    printf '\nOptional article:\n'
+    printf "  ${name} %s\n" \
+      'not a number VALUE' \
+      'an existing PATH' \
+      'the file PATH'
 
     exit 0
   }

--- a/is.sh
+++ b/is.sh
@@ -80,77 +80,77 @@ is() {
   #       it is being kept for consistency
   case "$condition" in
     file)
-      [ -f "$1" ]; return $?;;
+      [ -f "$1" ];;
     dir|directory)
-      [ -d "$1" ]; return $?;;
+      [ -d "$1" ];;
     link|symlink)
-      [ -L "$1" ]; return $?;;
+      [ -L "$1" ];;
     existent|existing|exist|exists)
-      [ -e "$1" ]; return $?;;
+      [ -e "$1" ];;
     readable)
-      [ -r "$1" ]; return $?;;
+      [ -r "$1" ];;
     writeable)
-      [ -w "$1" ]; return $?;;
+      [ -w "$1" ];;
     executable)
-      [ -x "$1" ]; return $?;;
+      [ -x "$1" ];;
     available|installed)
-      which "$1"; return $?;;
+      which "$1";;
     empty)
-      [ -z "$1" ]; return $?;;
+      [ -z "$1" ];;
     number)
-      printf '%s' "$1" | grep -E '^[0-9]+(\.[0-9]+)?$'; return $?;;
+      printf '%s' "$1" | grep -E '^[0-9]+(\.[0-9]+)?$';;
     older)
-      [ "$1" -ot "$2" ]; return $?;;
+      [ "$1" -ot "$2" ];;
     newer)
-      [ "$1" -nt "$2" ]; return $?;;
+      [ "$1" -nt "$2" ];;
     gt)
       is not a number "$1" && return 1;
       is not a number "$2" && return 1;
-      awk "BEGIN {exit $1 > $2 ? 0 : 1}"; return $?;;
+      awk "BEGIN {exit $1 > $2 ? 0 : 1}";;
     lt)
       is not a number "$1" && return 1;
       is not a number "$2" && return 1;
-      awk "BEGIN {exit $1 < $2 ? 0 : 1}"; return $?;;
+      awk "BEGIN {exit $1 < $2 ? 0 : 1}";;
     ge)
       is not a number "$1" && return 1;
       is not a number "$2" && return 1;
-      awk "BEGIN {exit $1 >= $2 ? 0 : 1}"; return $?;;
+      awk "BEGIN {exit $1 >= $2 ? 0 : 1}";;
     le)
       is not a number "$1" && return 1;
       is not a number "$2" && return 1;
-      awk "BEGIN {exit $1 <= $2 ? 0 : 1}"; return $?;;
+      awk "BEGIN {exit $1 <= $2 ? 0 : 1}";;
     eq|equal)
       [ "$1" = "$2" ] && return 0;
       is not a number "$1" && return 1;
       is not a number "$2" && return 1;
-      awk "BEGIN {exit $1 == $2 ? 0 : 1}"; return $?;;
+      awk "BEGIN {exit $1 == $2 ? 0 : 1}";;
     match|matching)
-      printf '%s' "$2" | grep -xE "$1"; return $?;;
+      printf '%s' "$2" | grep -xE "$1";;
     substr|substring)
       case $2 in
         *$1*) true;; *) false;; esac;;
     true)
-      [ "$1" == true ] || [ "$1" == 0 ]; return $?;;
+      [ "$1" == true ] || [ "$1" == 0 ];;
     false)
-      [ "$1" != true ] && [ "$1" != 0 ]; return $?;;
+      [ "$1" != true ] && [ "$1" != 0 ];;
     set|var|variable)
       # cross-sh-compatible sans `pdksh v5.2.14` treats expanded empty as unset
       # @see http://mywiki.wooledge.org/BashFAQ/083
-      local x; eval x="\"\${$1+set}\""; [ "$x" = 'set' ]; return $?;;
+      local x; eval x="\"\${$1+set}\""; [ "$x" = 'set' ];;
     alias)
-      is '_type' 'alias' "$1" || [ "${BASH_ALIASES[$1]+"set"}" = 'set' ]; return $?;;
+      is '_type' 'alias' "$1" || [ "${BASH_ALIASES[$1]+"set"}" = 'set' ];;
     builtin)
-      is '_type' 'builtin' "$1"; return $?;;
+      is '_type' 'builtin' "$1";;
     fn|function)
-      is '_type' 'function' "$1"; return $?;;
+      is '_type' 'function' "$1";;
     keyword)
-      is '_type' 'keyword' "$1"; return $?;;
+      is '_type' 'keyword' "$1";;
     _type)
       LANG=C \type ${BASH_VERSION:+-t} "$2" 2> /dev/null \
-        | \grep "${KSH_VERSION:+"$2 is a "}$1" 1> /dev/null; return $?;;
+        | \grep "${KSH_VERSION:+"$2 is a "}$1" 1> /dev/null;;
   esac 1> /dev/null
 
-  return 1
+  return $?
 }
 
 if [ "${BASH_SOURCE[0]}" != "${0}" ]; then

--- a/is.sh
+++ b/is.sh
@@ -63,7 +63,9 @@ is() {
   [ "$1" = '--help' ] && is::show.help && return 0
   [ "$1" = '--version' ] && is::show.version && return 0
 
-  local condition="$1" && shift 1
+  # Since we currently support bash v3.2.57, we can't use `"${1,,}"`
+  local condition=$1 && shift 1
+  condition="$(printf '%s' "${condition}" | tr '[:upper:]' '[:lower:]')"
 
   if [ "$condition" = 'not' ]; then
     ! is "${@}"

--- a/is.sh
+++ b/is.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-#
-# Copyright (c) 2016 Józef Sokołowski
-# Distributed under the MIT License
-#
-# For most current version checkout repository:
-# https://github.com/qzb/is.sh
-#
+###
+ # @author Józef Sokołowski
+ # @copyright 2015-2019 Józef Sokołowski
+ # @license MIT
+ # @see https://github.com/qzb/is.sh
+##
 
 is() {
     if [ "$1" == "--help" ]; then

--- a/is.sh
+++ b/is.sh
@@ -9,7 +9,17 @@
 is() {
   local name="${FUNCNAME[0]}" version='1.1.2'
 
+  # shellcheck disable=SC2016
   is::show.help() {
+    command printf 'Note:\n'
+    command printf ' - %s\n   %s\n' \
+      'The provided condition is case-insensitive.' \
+        'i.e the following conditions are equivalent: `is dir` === `is DIR`' \
+      'Conditions evaluate by value with the exception of those that' \
+        'accept `COMMAND` or `NAME`; they will evaluate by reference.' \
+      'Conditions may have multiple patterns they will match.' \
+        'Those will be listed inline and comma separated.'
+
     command printf 'Conditions:\n'
     command printf "  ${name} %s\n" \
       'equal VALUE_A VALUE_B, eq VALUE_A VALUE_B' \

--- a/is.sh
+++ b/is.sh
@@ -94,25 +94,25 @@ is() {
     newer)
       [ "$1" -nt "$2" ]; return $?;;
     gt)
-      is not a number "$1"      && return 1;
-      is not a number "$2"      && return 1;
+      is not a number "$1" && return 1;
+      is not a number "$2" && return 1;
       awk "BEGIN {exit $1 > $2 ? 0 : 1}"; return $?;;
     lt)
-      is not a number "$1"      && return 1;
-      is not a number "$2"      && return 1;
+      is not a number "$1" && return 1;
+      is not a number "$2" && return 1;
       awk "BEGIN {exit $1 < $2 ? 0 : 1}"; return $?;;
     ge)
-      is not a number "$1"      && return 1;
-      is not a number "$2"      && return 1;
+      is not a number "$1" && return 1;
+      is not a number "$2" && return 1;
       awk "BEGIN {exit $1 >= $2 ? 0 : 1}"; return $?;;
     le)
-      is not a number "$1"      && return 1;
-      is not a number "$2"      && return 1;
+      is not a number "$1" && return 1;
+      is not a number "$2" && return 1;
       awk "BEGIN {exit $1 <= $2 ? 0 : 1}"; return $?;;
     eq|equal)
-      [ "$1" = "$2" ]     && return 0;
-      is not a number "$1"      && return 1;
-      is not a number "$2"      && return 1;
+      [ "$1" = "$2" ] && return 0;
+      is not a number "$1" && return 1;
+      is not a number "$2" && return 1;
       awk "BEGIN {exit $1 == $2 ? 0 : 1}"; return $?;;
     match|matching)
       echo "$2" | grep -xE "$1"; return $?;;

--- a/is.sh
+++ b/is.sh
@@ -44,13 +44,18 @@ is() {
         exit 0
     }
 
+    is::show.version() {
+        echo "is.sh 1.1.0"
+
+        exit 0
+    }
+
     if [ "$1" == '--help' ]; then
         is::show.help
     fi
 
     if [ "$1" == '--version' ]; then
-        echo "is.sh 1.1.0"
-        exit
+        is::show.version
     fi
 
   local condition="$1" && shift 1

--- a/is.sh
+++ b/is.sh
@@ -98,7 +98,8 @@ is() {
     empty)
       [ -z "$1" ];;
     number)
-      printf '%s' "$1" | grep -E '^[0-9]+(\.[0-9]+)?$';;
+      printf '%s' "$1" \
+        | grep -E '^[-+]?([0-9]+\.?|[0-9]*\.[0-9]+)$' 1> /dev/null;;
     older)
       [ "$1" -ot "$2" ];;
     newer)

--- a/is.sh
+++ b/is.sh
@@ -7,6 +7,8 @@
 ##
 
 is() {
+  local name="${FUNCNAME[0]}" version='1.1.0'
+
   is::show.help() {
     cat <<- EOF
 			Conditions:
@@ -45,7 +47,7 @@ is() {
   }
 
   is::show.version() {
-    printf 'is.sh 1.1.0'
+    printf '%s %s\n' "${name}" "${version}"
 
     exit 0
   }

--- a/is.sh
+++ b/is.sh
@@ -7,134 +7,134 @@
 ##
 
 is() {
-    is::show.help() {
-        cat <<- EOF
-					Conditions:
-					  is equal VALUE_A VALUE_B
-					  is matching REGEXP VALUE
-					  is substring VALUE_A VALUE_B
-					  is empty VALUE
-					  is number VALUE
-					  is gt NUMBER_A NUMBER_B
-					  is lt NUMBER_A NUMBER_B
-					  is ge NUMBER_A NUMBER_B
-					  is le NUMBER_A NUMBER_B
-					  is file PATH
-					  is dir PATH
-					  is link PATH
-					  is existing PATH
-					  is readable PATH
-					  is writeable PATH
-					  is executable PATH
-					  is available COMMAND
-					  is older PATH_A PATH_B
-					  is newer PATH_A PATH_B
-					  is true VALUE
-					  is false VALUE
+  is::show.help() {
+    cat <<- EOF
+			Conditions:
+			  is equal VALUE_A VALUE_B
+			  is matching REGEXP VALUE
+			  is substring VALUE_A VALUE_B
+			  is empty VALUE
+			  is number VALUE
+			  is gt NUMBER_A NUMBER_B
+			  is lt NUMBER_A NUMBER_B
+			  is ge NUMBER_A NUMBER_B
+			  is le NUMBER_A NUMBER_B
+			  is file PATH
+			  is dir PATH
+			  is link PATH
+			  is existing PATH
+			  is readable PATH
+			  is writeable PATH
+			  is executable PATH
+			  is available COMMAND
+			  is older PATH_A PATH_B
+			  is newer PATH_A PATH_B
+			  is true VALUE
+			  is false VALUE
 
-					Negation:
-					  is not equal VALUE_A VALUE_B
+			Negation:
+			  is not equal VALUE_A VALUE_B
 
-					Optional article:
-					  is not a number VALUE
-					  is an existing PATH
-					  is the file PATH
-				EOF
+			Optional article:
+			  is not a number VALUE
+			  is an existing PATH
+			  is the file PATH
+		EOF
 
-        exit 0
-    }
+    exit 0
+  }
 
-    is::show.version() {
-        echo "is.sh 1.1.0"
+  is::show.version() {
+    echo "is.sh 1.1.0"
 
-        exit 0
-    }
+    exit 0
+  }
 
-    if [ "$1" == '--help' ]; then
-        is::show.help
-    fi
+  if [ "$1" == '--help' ]; then
+    is::show.help
+  fi
 
-    if [ "$1" == '--version' ]; then
-        is::show.version
-    fi
+  if [ "$1" == '--version' ]; then
+    is::show.version
+  fi
 
   local condition="$1" && shift 1
 
   if [ "$condition" = 'not' ]; then
-        ! is "${@}"
-        return $?
-    fi
+    ! is "${@}"
+    return $?
+  fi
 
   if [ "$condition" == 'a' ] || [ "$condition" == 'an' ] \
     || [ "$condition" == 'the' ]; then
-        is "${@}"
-        return $?
-    fi
+      is "${@}"
+      return $?
+  fi
 
   # Note: case statements takes an expression & therefore doesn't need quotes
   #       it is being kept for consistency
-    case "$condition" in
-        file)
-            [ -f "$1" ]; return $?;;
-        dir|directory)
-            [ -d "$1" ]; return $?;;
-        link|symlink)
-            [ -L "$1" ]; return $?;;
-        existent|existing|exist|exists)
-            [ -e "$1" ]; return $?;;
-        readable)
-            [ -r "$1" ]; return $?;;
-        writeable)
-            [ -w "$1" ]; return $?;;
-        executable)
-            [ -x "$1" ]; return $?;;
-        available|installed)
-            which "$1"; return $?;;
-        empty)
-            [ -z "$1" ]; return $?;;
-        number)
-            echo "$1" | grep -E '^[0-9]+(\.[0-9]+)?$'; return $?;;
-        older)
-            [ "$1" -ot "$2" ]; return $?;;
-        newer)
-            [ "$1" -nt "$2" ]; return $?;;
-        gt)
-            is not a number "$1"      && return 1;
-            is not a number "$2"      && return 1;
-            awk "BEGIN {exit $1 > $2 ? 0 : 1}"; return $?;;
-        lt)
-            is not a number "$1"      && return 1;
-            is not a number "$2"      && return 1;
-            awk "BEGIN {exit $1 < $2 ? 0 : 1}"; return $?;;
-        ge)
-            is not a number "$1"      && return 1;
-            is not a number "$2"      && return 1;
-            awk "BEGIN {exit $1 >= $2 ? 0 : 1}"; return $?;;
-        le)
-            is not a number "$1"      && return 1;
-            is not a number "$2"      && return 1;
-            awk "BEGIN {exit $1 <= $2 ? 0 : 1}"; return $?;;
-        eq|equal)
-            [ "$1" = "$2" ]     && return 0;
-            is not a number "$1"      && return 1;
-            is not a number "$2"      && return 1;
-            awk "BEGIN {exit $1 == $2 ? 0 : 1}"; return $?;;
-        match|matching)
-            echo "$2" | grep -xE "$1"; return $?;;
-        substr|substring)
-            echo "$2" | grep -F "$1"; return $?;;
-        true)
-            [ "$1" == true ] || [ "$1" == 0 ]; return $?;;
-        false)
-            [ "$1" != true ] && [ "$1" != 0 ]; return $?;;
-    esac > /dev/null
+  case "$condition" in
+    file)
+      [ -f "$1" ]; return $?;;
+    dir|directory)
+      [ -d "$1" ]; return $?;;
+    link|symlink)
+      [ -L "$1" ]; return $?;;
+    existent|existing|exist|exists)
+      [ -e "$1" ]; return $?;;
+    readable)
+      [ -r "$1" ]; return $?;;
+    writeable)
+      [ -w "$1" ]; return $?;;
+    executable)
+      [ -x "$1" ]; return $?;;
+    available|installed)
+      which "$1"; return $?;;
+    empty)
+      [ -z "$1" ]; return $?;;
+    number)
+      echo "$1" | grep -E '^[0-9]+(\.[0-9]+)?$'; return $?;;
+    older)
+      [ "$1" -ot "$2" ]; return $?;;
+    newer)
+      [ "$1" -nt "$2" ]; return $?;;
+    gt)
+      is not a number "$1"      && return 1;
+      is not a number "$2"      && return 1;
+      awk "BEGIN {exit $1 > $2 ? 0 : 1}"; return $?;;
+    lt)
+      is not a number "$1"      && return 1;
+      is not a number "$2"      && return 1;
+      awk "BEGIN {exit $1 < $2 ? 0 : 1}"; return $?;;
+    ge)
+      is not a number "$1"      && return 1;
+      is not a number "$2"      && return 1;
+      awk "BEGIN {exit $1 >= $2 ? 0 : 1}"; return $?;;
+    le)
+      is not a number "$1"      && return 1;
+      is not a number "$2"      && return 1;
+      awk "BEGIN {exit $1 <= $2 ? 0 : 1}"; return $?;;
+    eq|equal)
+      [ "$1" = "$2" ]     && return 0;
+      is not a number "$1"      && return 1;
+      is not a number "$2"      && return 1;
+      awk "BEGIN {exit $1 == $2 ? 0 : 1}"; return $?;;
+    match|matching)
+      echo "$2" | grep -xE "$1"; return $?;;
+    substr|substring)
+      echo "$2" | grep -F "$1"; return $?;;
+    true)
+      [ "$1" == true ] || [ "$1" == 0 ]; return $?;;
+    false)
+      [ "$1" != true ] && [ "$1" != 0 ]; return $?;;
+  esac > /dev/null
 
-    return 1
+  return 1
 }
 
 if is not equal "${BASH_SOURCE[0]}" "$0"; then
-    export -f is
+  export -f is
 else
-    is "${@}"
-    exit $?
+  is "${@}"
+  exit $?
 fi

--- a/is.sh
+++ b/is.sh
@@ -122,7 +122,8 @@ is() {
     match|matching)
       printf '%s' "$2" | grep -xE "$1"; return $?;;
     substr|substring)
-      printf '%s' "$2" | grep -F "$1"; return $?;;
+      case $2 in
+        *$1*) true;; *) false;; esac;;
     true)
       [ "$1" == true ] || [ "$1" == 0 ]; return $?;;
     false)

--- a/is.sh
+++ b/is.sh
@@ -7,40 +7,45 @@
 ##
 
 is() {
+    is::show.help() {
+        cat <<- EOF
+					Conditions:
+					  is equal VALUE_A VALUE_B
+					  is matching REGEXP VALUE
+					  is substring VALUE_A VALUE_B
+					  is empty VALUE
+					  is number VALUE
+					  is gt NUMBER_A NUMBER_B
+					  is lt NUMBER_A NUMBER_B
+					  is ge NUMBER_A NUMBER_B
+					  is le NUMBER_A NUMBER_B
+					  is file PATH
+					  is dir PATH
+					  is link PATH
+					  is existing PATH
+					  is readable PATH
+					  is writeable PATH
+					  is executable PATH
+					  is available COMMAND
+					  is older PATH_A PATH_B
+					  is newer PATH_A PATH_B
+					  is true VALUE
+					  is false VALUE
+
+					Negation:
+					  is not equal VALUE_A VALUE_B
+
+					Optional article:
+					  is not a number VALUE
+					  is an existing PATH
+					  is the file PATH
+				EOF
+
+        exit 0
+    }
+
     if [ "$1" == '--help' ]; then
-        cat << EOF
-Conditions:
-  is equal VALUE_A VALUE_B
-  is matching REGEXP VALUE
-  is substring VALUE_A VALUE_B
-  is empty VALUE
-  is number VALUE
-  is gt NUMBER_A NUMBER_B
-  is lt NUMBER_A NUMBER_B
-  is ge NUMBER_A NUMBER_B
-  is le NUMBER_A NUMBER_B
-  is file PATH
-  is dir PATH
-  is link PATH
-  is existing PATH
-  is readable PATH
-  is writeable PATH
-  is executable PATH
-  is available COMMAND
-  is older PATH_A PATH_B
-  is newer PATH_A PATH_B
-  is true VALUE
-  is false VALUE
-
-Negation:
-  is not equal VALUE_A VALUE_B
-
-Optional article:
-  is not a number VALUE
-  is an existing PATH
-  is the file PATH
-EOF
-        exit
+        is::show.help
     fi
 
     if [ "$1" == '--version' ]; then

--- a/is.sh
+++ b/is.sh
@@ -101,7 +101,7 @@ is() {
       command -v "$1" -- 2> /dev/null;;
     empty)
       [ -z "$1" ];;
-    number)
+    num|number)
       # for compatibility w/ versions < 3.2, regex must be stored in variable
       local regex='^[-+]?([0-9]+\.?|[0-9]*\.[0-9]+)$'
       [[ $1 = *[0-9]* && $1 =~ $regex ]];;

--- a/is.sh
+++ b/is.sh
@@ -90,11 +90,10 @@ is() {
     return $?
   fi
 
-  if [ "$condition" == 'a' ] || [ "$condition" == 'an' ] \
-    || [ "$condition" == 'the' ]; then
-      is "${@}"
-      return $?
-  fi
+  while [ "$condition" == 'a' ] || [ "$condition" == 'an' ] \
+    || [ "$condition" == 'the' ]; do :
+    condition=$1 && shift 1
+  done
 
   # Note: case statements takes an expression & therefore doesn't need quotes
   #       it is being kept for consistency

--- a/is.sh
+++ b/is.sh
@@ -98,15 +98,15 @@ is() {
   local condition=$1 && shift 1
   condition=$(is::tolower "$condition")
 
-  if [ "$condition" = 'not' ]; then
-    ! is "${@}"
-    return $?
-  fi
-
   while [ "$condition" == 'a' ] || [ "$condition" == 'an' ] \
     || [ "$condition" == 'the' ]; do :
     condition=$(is::tolower "$1") && shift 1
   done
+
+  if [ "$condition" = 'not' ]; then
+    ! is "${@}"
+    return $?
+  fi
 
   # Note: case statements takes an expression & therefore doesn't need quotes
   #       it is being kept for consistency

--- a/is.sh
+++ b/is.sh
@@ -44,12 +44,14 @@ is() {
       'an existing PATH' \
       'the file PATH'
 
+    unset ${BASH_VERSION:+-f}
     exit 0
   }
 
   is::show.version() {
     printf '%s %s\n' "${name}" "${version}"
 
+    unset ${BASH_VERSION:+-f}
     exit 0
   }
 

--- a/is.sh
+++ b/is.sh
@@ -12,33 +12,40 @@ is() {
   is::show.help() {
     command printf 'Conditions:\n'
     command printf "  ${name} %s\n" \
-      'equal VALUE_A VALUE_B' \
-      'matching REGEXP VALUE' \
-      'substring VALUE_A VALUE_B' \
+      'equal VALUE_A VALUE_B, eq VALUE_A VALUE_B' \
+      'matching REGEXP VALUE, match REGEXP VALUE' \
+      'substring VALUE_A VALUE_B, substr VALUE_A VALUE_B' \
       'empty VALUE' \
-      'number VALUE' \
+      'number VALUE, num VALUE' \
       'gt NUMBER_A NUMBER_B' \
       'lt NUMBER_A NUMBER_B' \
       'ge NUMBER_A NUMBER_B' \
       'le NUMBER_A NUMBER_B' \
       'file PATH' \
-      'dir PATH' \
-      'link PATH' \
-      'existing PATH' \
+      'dir PATH, directory PATH' \
+      'link PATH, symlink PATH' \
+      'existent PATH, existing PATH, exist PATH, exists PATH' \
       'readable PATH' \
       'writeable PATH' \
       'executable PATH' \
-      'available COMMAND' \
+      'available COMMAND, installed COMMAND' \
+      'cmd COMMAND, command COMMAND' \
       'older PATH_A PATH_B' \
       'newer PATH_A PATH_B' \
       'true VALUE' \
       'false VALUE' \
+      'bool VALUE, boolean VALUE' \
+      'truthy VALUE' \
+      'falsey VALUE' \
       'set NAME, var NAME, variable NAME' \
-      'false VALUE' \
       'alias NAME' \
       'builtin NAME' \
       'function NAME, fn NAME' \
-      'keyword NAME'
+      'keyword NAME' \
+      'array NAME' \
+      'exported NAME' \
+      'int NAME, int VALUE, integer NAME, integer VALUE' \
+      'hash NAME'
 
     command printf '\nNegation:\n'
     command printf "  ${name} %s\n" \

--- a/is.sh
+++ b/is.sh
@@ -127,7 +127,7 @@ is() {
   return 1
 }
 
-if is not equal "${BASH_SOURCE[0]}" "$0"; then
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
   export -f is
 else
   is "${@}"

--- a/is.sh
+++ b/is.sh
@@ -129,6 +129,14 @@ is() {
       [ "$1" == true ] || [ "$1" == 0 ];;
     false)
       [ "$1" != true ] && [ "$1" != 0 ];;
+    bool|boolean)
+      is 'truthy' "$1" || is 'falsey' "$1" || return 2;;
+    truthy)
+      case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+        0|t|y|true|yes|on) true;; *) false;; esac;;
+    falsey)
+      case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+        1|f|n|false|no|off) true;; *) false;; esac;;
     set|var|variable)
       # cross-sh-compatible sans `pdksh v5.2.14` treats expanded empty as unset
       # @see http://mywiki.wooledge.org/BashFAQ/083

--- a/is.sh
+++ b/is.sh
@@ -33,7 +33,12 @@ is() {
       'newer PATH_A PATH_B' \
       'true VALUE' \
       'false VALUE' \
-      'set NAME, var NAME, variable NAME'
+      'set NAME, var NAME, variable NAME' \
+      'false VALUE' \
+      'alias NAME' \
+      'builtin NAME' \
+      'function NAME, fn NAME' \
+      'keyword NAME'
 
     printf '\nNegation:\n'
     printf "  ${name} %s\n" \
@@ -132,6 +137,17 @@ is() {
       # cross-sh-compatible sans `pdksh v5.2.14` treats expanded empty as unset
       # @see http://mywiki.wooledge.org/BashFAQ/083
       local x; eval x="\"\${$1+set}\""; [ "$x" = 'set' ]; return $?;;
+    alias)
+      is '_type' 'alias' "$1" || [ "${BASH_ALIASES[$1]+"set"}" = 'set' ]; return $?;;
+    builtin)
+      is '_type' 'builtin' "$1"; return $?;;
+    fn|function)
+      is '_type' 'function' "$1"; return $?;;
+    keyword)
+      is '_type' 'keyword' "$1"; return $?;;
+    _type)
+      LANG=C \type ${BASH_VERSION:+-t} "$2" 2> /dev/null \
+        | \grep "${KSH_VERSION:+"$2 is a "}$1" 1> /dev/null; return $?;;
   esac 1> /dev/null
 
   return 1

--- a/is.sh
+++ b/is.sh
@@ -123,6 +123,7 @@ is() {
     executable)
       [ -x "$1" ];;
     available|installed)
+      # shellcheck disable=SC2230
       which "$1";;
     cmd|command)
       command -v "$1" -- 2> /dev/null;;

--- a/is.sh
+++ b/is.sh
@@ -106,26 +106,17 @@ is() {
     newer)
       [ "$1" -nt "$2" ];;
     gt)
-      is not a number "$1" && return 1;
-      is not a number "$2" && return 1;
-      awk "BEGIN {exit $1 > $2 ? 0 : 1}";;
+      is '_compare' "${@}" '>';;
     lt)
-      is not a number "$1" && return 1;
-      is not a number "$2" && return 1;
-      awk "BEGIN {exit $1 < $2 ? 0 : 1}";;
+      is '_compare' "${@}" '<';;
     ge)
-      is not a number "$1" && return 1;
-      is not a number "$2" && return 1;
-      awk "BEGIN {exit $1 >= $2 ? 0 : 1}";;
+      is '_compare' "${@}" '>=';;
     le)
-      is not a number "$1" && return 1;
-      is not a number "$2" && return 1;
-      awk "BEGIN {exit $1 <= $2 ? 0 : 1}";;
+      is '_compare' "${@}" '<=';;
     eq|equal)
-      [ "$1" = "$2" ] && return 0;
-      is not a number "$1" && return 1;
-      is not a number "$2" && return 1;
-      awk "BEGIN {exit $1 == $2 ? 0 : 1}";;
+      [ "$1" = "$2" ] || is '_compare' "${@}" '==';;
+    _compare)
+      is number "$1" && is number "$2" && awk "BEGIN {exit $1 $3 $2 ? 0 : 1}";;
     match|matching)
       printf '%s' "$2" | grep -xE "$1";;
     substr|substring)

--- a/is.sh
+++ b/is.sh
@@ -148,6 +148,7 @@ is() {
     _type)
       LANG=C \type ${BASH_VERSION:+-t} "$2" 2> /dev/null \
         | \grep "${KSH_VERSION:+"$2 is a "}$1" 1> /dev/null;;
+    *) false ;;
   esac 1> /dev/null
 
   return $?

--- a/is.sh
+++ b/is.sh
@@ -95,6 +95,8 @@ is() {
       [ -x "$1" ];;
     available|installed)
       which "$1";;
+    cmd|command)
+      command -v "$1" -- 2> /dev/null;;
     empty)
       [ -z "$1" ];;
     number)

--- a/is.sh
+++ b/is.sh
@@ -53,9 +53,10 @@ is() {
       'function NAME, fn NAME' \
       'keyword NAME' \
       'array NAME' \
-      'exported NAME' \
+      'exported NAME, export NAME' \
       'int NAME, int VALUE, integer NAME, integer VALUE' \
-      'hash NAME'
+      'hash NAME, dictionary NAME' \
+      'in $VALUE NAME'
 
     command printf '\nNegation:\n'
     command printf "  ${name} %s\n" \

--- a/is.sh
+++ b/is.sh
@@ -142,6 +142,12 @@ is() {
     _type)
       LANG=C command type ${BASH_VERSION:+-t} "$2" 2> /dev/null \
         | command grep "${KSH_VERSION:+"$2 is a "}$1" 1> /dev/null;;
+    in)
+      # currently does not handle being passed in a string instead of an array
+      # use a subshell so as to preserve $IFS
+      ( local localarray IFS=$'\a\b\a'
+      eval "localarray=( \"\${$2[@]}\" )"
+      is 'substring' "$IFS$1$IFS" "$IFS${localarray[*]}$IFS" );;
     *) false ;;
   esac 1> /dev/null
 

--- a/is.sh
+++ b/is.sh
@@ -45,7 +45,7 @@ is() {
   }
 
   is::show.version() {
-    echo "is.sh 1.1.0"
+    printf 'is.sh 1.1.0'
 
     exit 0
   }
@@ -88,7 +88,7 @@ is() {
     empty)
       [ -z "$1" ]; return $?;;
     number)
-      echo "$1" | grep -E '^[0-9]+(\.[0-9]+)?$'; return $?;;
+      printf '%s' "$1" | grep -E '^[0-9]+(\.[0-9]+)?$'; return $?;;
     older)
       [ "$1" -ot "$2" ]; return $?;;
     newer)
@@ -115,9 +115,9 @@ is() {
       is not a number "$2" && return 1;
       awk "BEGIN {exit $1 == $2 ? 0 : 1}"; return $?;;
     match|matching)
-      echo "$2" | grep -xE "$1"; return $?;;
+      printf '%s' "$2" | grep -xE "$1"; return $?;;
     substr|substring)
-      echo "$2" | grep -F "$1"; return $?;;
+      printf '%s' "$2" | grep -F "$1"; return $?;;
     true)
       [ "$1" == true ] || [ "$1" == 0 ]; return $?;;
     false)

--- a/is.sh
+++ b/is.sh
@@ -10,8 +10,8 @@ is() {
   local name="${FUNCNAME[0]}" version='1.1.0'
 
   is::show.help() {
-    printf 'Conditions:\n'
-    printf "  ${name} %s\n" \
+    command printf 'Conditions:\n'
+    command printf "  ${name} %s\n" \
       'equal VALUE_A VALUE_B' \
       'matching REGEXP VALUE' \
       'substring VALUE_A VALUE_B' \
@@ -40,23 +40,23 @@ is() {
       'function NAME, fn NAME' \
       'keyword NAME'
 
-    printf '\nNegation:\n'
-    printf "  ${name} %s\n" \
+    command printf '\nNegation:\n'
+    command printf "  ${name} %s\n" \
       'not equal VALUE_A VALUE_B'
 
-    printf '\nOptional article:\n'
-    printf "  ${name} %s\n" \
+    command printf '\nOptional article:\n'
+    command printf "  ${name} %s\n" \
       'not a number VALUE' \
       'an existing PATH' \
       'the file PATH'
 
-    unset ${BASH_VERSION:+-f}
+    command unset ${BASH_VERSION:+-f}
   }
 
   is::show.version() {
-    printf '%s %s\n' "${name}" "${version}"
+    command printf '%s %s\n' "${name}" "${version}"
 
-    unset ${BASH_VERSION:+-f}
+    command unset ${BASH_VERSION:+-f}
   }
 
   [ "$#" -eq 0 ] && is::show.version && is::show.help && return 0
@@ -116,9 +116,10 @@ is() {
     eq|equal)
       [ "$1" = "$2" ] || is '_compare' "${@}" '==';;
     _compare)
-      is number "$1" && is number "$2" && awk "BEGIN {exit $1 $3 $2 ? 0 : 1}";;
+      is number "$1" && is number "$2" \
+        && command awk "BEGIN {exit $1 $3 $2 ? 0 : 1}";;
     match|matching)
-      printf '%s' "$2" | grep -xE "$1";;
+      command printf '%s' "$2" | command grep -xE "$1";;
     substr|substring)
       case $2 in
         *$1*) true;; *) false;; esac;;
@@ -139,8 +140,8 @@ is() {
     keyword)
       is '_type' 'keyword' "$1";;
     _type)
-      LANG=C \type ${BASH_VERSION:+-t} "$2" 2> /dev/null \
-        | \grep "${KSH_VERSION:+"$2 is a "}$1" 1> /dev/null;;
+      LANG=C command type ${BASH_VERSION:+-t} "$2" 2> /dev/null \
+        | command grep "${KSH_VERSION:+"$2 is a "}$1" 1> /dev/null;;
     *) false ;;
   esac 1> /dev/null
 

--- a/is.sh
+++ b/is.sh
@@ -32,7 +32,8 @@ is() {
       'older PATH_A PATH_B' \
       'newer PATH_A PATH_B' \
       'true VALUE' \
-      'false VALUE'
+      'false VALUE' \
+      'set NAME, var NAME, variable NAME'
 
     printf '\nNegation:\n'
     printf "  ${name} %s\n" \
@@ -126,6 +127,10 @@ is() {
       [ "$1" == true ] || [ "$1" == 0 ]; return $?;;
     false)
       [ "$1" != true ] && [ "$1" != 0 ]; return $?;;
+    set|var|variable)
+      # cross-sh-compatible sans `pdksh v5.2.14` treats expanded empty as unset
+      # @see http://mywiki.wooledge.org/BashFAQ/083
+      local x; eval x="\"\${$1+set}\""; [ "$x" = 'set' ]; return $?;;
   esac 1> /dev/null
 
   return 1

--- a/is.sh
+++ b/is.sh
@@ -45,18 +45,17 @@ is() {
       'the file PATH'
 
     unset ${BASH_VERSION:+-f}
-    exit 0
   }
 
   is::show.version() {
     printf '%s %s\n' "${name}" "${version}"
 
     unset ${BASH_VERSION:+-f}
-    exit 0
   }
 
-  [ "$1" = '--help' ] && is::show.help
-  [ "$1" = '--version' ] && is::show.version
+  [ "$#" -eq 0 ] && is::show.version && is::show.help && return 0
+  [ "$1" = '--help' ] && is::show.help && return 0
+  [ "$1" = '--version' ] && is::show.version && return 0
 
   local condition="$1" && shift 1
 

--- a/is.sh
+++ b/is.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Józef Sokołowski
 # Distributed under the MIT License

--- a/is.sh
+++ b/is.sh
@@ -64,6 +64,8 @@ EOF
         return $?
     fi
 
+  # Note: case statements takes an expression & therefore doesn't need quotes
+  #       it is being kept for consistency
     case "$condition" in
         file)
             [ -f "$value_a" ]; return $?;;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is.sh",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Human readable conditions for bash",
   "keywords": [
     "shell",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "tests"
   },
   "scripts": {
+    "is": "./is.sh",
     "lint": "shellcheck is.sh",
     "test": "./tests/tests.sh"
   },

--- a/tests/assert.sh
+++ b/tests/assert.sh
@@ -74,9 +74,9 @@ assert_end() {
     # assert_end [suite ..]
     tests_endtime="$(date +%s%N)"
     # required visible decimal place for seconds (leading zeros if needed)
-    local tests_time="$( \
-        printf "%010d" "$(( ${tests_endtime/%N/000000000} 
-                            - ${tests_starttime/%N/000000000} ))")"  # in ns
+    local tests_time="$(printf "%010d" \
+        "$(( ${tests_endtime/%N/000000000} - ${tests_starttime/%N/000000000} ))"
+    )"  # in ns
     tests="$tests_ran ${*:+$* }tests"
     [[ -n "$DISCOVERONLY" ]] && echo "collected $tests." && _assert_reset && return
     [[ -n "$DEBUG" ]] && echo

--- a/tests/assert.sh
+++ b/tests/assert.sh
@@ -62,17 +62,19 @@ EOF
 done
 
 _indent=$'\n\t' # local format helper
+_date=date
+[ $(uname) = 'Darwin' ] && _date=gdate
 
 _assert_reset() {
     tests_ran=0
     tests_failed=0
     tests_errors=()
-    tests_starttime="$(date +%s%N)" # nanoseconds_since_epoch
+    tests_starttime="$($_date +%s%N)" # nanoseconds_since_epoch
 }
 
 assert_end() {
     # assert_end [suite ..]
-    tests_endtime="$(date +%s%N)"
+    tests_endtime="$($_date +%s%N)"
     # required visible decimal place for seconds (leading zeros if needed)
     local tests_time="$(printf "%010d" \
         "$(( ${tests_endtime/%N/000000000} - ${tests_starttime/%N/000000000} ))"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$1" ] && ! which "$1" > /dev/null; then
     echo "$1 not found"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-if [ -n "$1" ] && ! which "$1" > /dev/null; then
+declare DIR CMD
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
+CMD="${1:-"$DIR/is.sh"}"
+
+if [ -n "$FILE" ] && ! which "$FILE" > /dev/null; then
     printf '%s not found.\n' "$FILE"
     exit 1
 fi
-
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd -P )
-CMD=$(which "${1:-$DIR/is.sh}")
 
 # : 1> file === touch file without calling an external tool
 # read -rst # -n 999 === sleep # without calling an external tool

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -208,6 +208,10 @@ printf 'Running tests\n' && {
   assert_false 'in' "$needle array_empty" "$needle array_withoutNeedle" \
     "$needle array_withNeedleasSubstring"
     assert_false 'in' 'a apple' # this may change
+
+  # is cmd|command
+  assert_true  'cmd' 'which'
+  assert_false 'command' 'witch'
 } && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # end of tests

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -12,10 +12,10 @@ FILE="${1:-"$DIR/is.sh"}"
 # read -rst # -n 999 === sleep # without calling an external tool
 # Prepare working directory
 # shellcheck disable=SC2034
-test::warm() {
+printf 'Warming Tests\n' && {
   command cd "$(mktemp -d)" || exit 1
 
-  declare -g path_file_abs="${PWD}/file_abs" path_dir_abs="${PWD}/dir_abs" \
+  declare path_file_abs="${PWD}/file_abs" path_dir_abs="${PWD}/dir_abs" \
     path_dir_rel='./dir_rel' \
     path_dir_symlink='dir_symlink' \
     path_file_forbidden='./file_forbidden' \
@@ -39,8 +39,8 @@ test::warm() {
   ln -s $path_file_rel $path_file_symlink
   ln -s $path_dir_rel $path_dir_symlink
 
-  declare -g bell=$'\a' backspace=$'\b' needle=':'
-  declare -ag array_empty=() \
+  declare bell=$'\a' backspace=$'\b' needle=':'
+  declare -a array_empty=() \
     array_withNeedle=(':') \
     array_withoutNeedle=('a' '' 0 true) \
     array_withNeedleasSubstring=(
@@ -127,7 +127,7 @@ test::warm() {
     ]]
   )
   # shellcheck disable=SC1010,SC1083
-  declare -ag array_keywords=(
+  declare -a array_keywords=(
     if then elif else fi
     for in do done
     while until
@@ -191,7 +191,7 @@ test::warm() {
       # \`\`
     ]
   )
-  declare -ag array_builtins_bash=(
+  declare -a array_builtins_bash=(
     alias unalias
     bind
     builtin
@@ -252,7 +252,7 @@ test::warm() {
 
   #  # These cause a EOF error due to improper parsing of command subsitution
   #   within comments
-  declare -ag parser_error_for_keyword_double_bracket=(
+  declare -a parser_error_for_keyword_double_bracket=(
     # [[
     #   # $([[)
     #   # $(]])
@@ -280,47 +280,47 @@ test::warm() {
     # ]
   )
 
-  declare -g var_declared var_unset=''
+  declare var_declared var_unset=''
   command unset ${BASH_VERSION+-v} var_unset
 
-  declare -g val_string='string' val_str='str' val_rtS='rtS' val_string_empty=''
+  declare val_string='string' val_str='str' val_rtS='rtS' val_string_empty=''
 
   # remember, -g just bring the variables scope to the top
   #   `declare -p` will not show `-g`
-  declare -gi var_gi=0
-  declare -ga var_ga=([0]='-ga')
-  declare -gA var_gA=([0]='-gA')
-  declare -gx var_gx='-x'
+  declare -i var_gi=0
+  declare -a var_ga=([0]='-ga')
+  declare -A var_gA=([0]='-gA')
+  declare -x var_gx='-x'
 
   # -{i,a,A}gx, -{i,a,A}xg, -gx{i,a,A}, -x{i,a,A}g, -xg{i,a,A},
   #   will all evaluate to -g{i,a,A}x
   #   likewise with -g{i,a,A}, -{i,a,A}g and then exporting
-  declare -gix var_gix=1
-  declare -gax var_gax=([0]='-gax')
-  declare -gAx var_gAx=([0]='-gAx')
+  declare -ix var_gix=1
+  declare -ax var_gax=([0]='-gax')
+  declare -Ax var_gAx=([0]='-gAx')
 
   command alias myAlias=''
-  declare -g ref_alias='myAlias' \
+  declare ref_alias='myAlias' \
     ref_builtin='printf' \
     ref_keyword='if' \
     ref_function='assert_true' \
     ref_var_gi='var_gi'
 
   # note: bash's goes up to but excludes uint64 (2**64); it will evaluate to 0
-  declare -g val_uint16=$((2**16)) val_uint32=$((2**32)) val_sint64=$((2**63-1))
-  declare -g val_nsint64=$((val_sint64+1)) # wraps to negative
+  declare val_uint16=$((2**16)) val_uint32=$((2**32)) val_sint64=$((2**63-1))
+  declare val_nsint64=$((val_sint64+1)) # wraps to negative
   val_sint64="+$val_sint64"
-  declare -g val_udec16dot0="$val_uint16.0"
+  declare val_udec16dot0="$val_uint16.0"
     val_udec16dot16="$val_uint16.$val_uint16"
 
-  declare -g val_rgb='0011ff' \
+  declare val_rgb='0011ff' \
     val_curreny_usd="'\$$val_uint16'" \
     val_e_notation="${val_uint16}e${val_uint16}" \
     val_nsdec16="-$val_udec16dot0" \
     val_sdec16="+$val_udec16dot0" \
     val_udec16comma0="$val_uint16,0"
 
-  declare -ga array_decimal=(
+  declare -a array_decimal=(
     "$val_nsdec16"
     "$val_sdec16"
     "$val_udec16dot0"
@@ -343,7 +343,7 @@ test::warm() {
     var_gax
     var_gAx
   )
-}
+} && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # Helpers
 _assert_raises() {
@@ -536,10 +536,6 @@ test::run() {
     "$needle array_withNeedleasSubstring"
     assert_false 'in' 'a apple' # this may change
 }
-
-printf 'Warming Tests\n' \
-  && test::warm \
-  && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # shellcheck source=./assert.sh
 . "$DIR/tests/assert.sh"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -148,6 +148,9 @@ printf 'Running tests\n' && {
   # help
   assert_true '--help'
 
+  # no args
+  assert_true ''
+
   # unknown condition
   assert_false 'spam' 'foo bar'
 } && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -40,7 +40,7 @@ assert_false() {
     assert_raises "$1" 1
 }
 
-# shellcheck source=/dev/null
+# shellcheck source=./assert.sh
 . "$DIR/tests/assert.sh"
 
 echo Testing \"$CMD\"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -n "$1" ] && ! which "$1" > /dev/null; then
-    echo "$1 not found"
+    printf '%s not found.\n' "$FILE"
     exit 1
 fi
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -33,6 +33,28 @@ printf 'Warming tests\n' && {
   declare var_declared
   declare var_initialized='' var_unset=''
   command unset ${BASH_VERSION+-v} var_unset
+
+  declare bell=$'\a' backspace=$'\b'
+  declare needle=':'
+  declare -a array_empty=()
+  declare -a array_withNeedle=(':')
+  declare -a array_withoutNeedle=('a' '' 0 true)
+  declare -a array_withNeedleasSubstring=(
+    " ${needle}"
+    "\\$needle"
+    "${backspace}${needle}"
+    "${bell}${backspace}${needle}"
+    "${bell}${needle}"
+    "${needle} "
+    "${needle}\a"
+    "${needle}${backspace}"
+    "${needle}${bell}"
+    "${needle}${bell}${backspace}"
+    "${needle}a"
+    "${needle}a${needle}"
+    "a${needle}"
+    ''
+  )
 } && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # Helpers
@@ -180,6 +202,12 @@ printf 'Running tests\n' && {
   # is set|var|variable
   assert_true  'set' 'var_initialized'
   assert_false 'var' 'var_declared' 'var_undeclared' 'var_unset'
+
+  # is in
+  assert_true  'in' "$needle array_withNeedle"
+  assert_false 'in' "$needle array_empty" "$needle array_withoutNeedle" \
+    "$needle array_withNeedleasSubstring"
+    assert_false 'in' 'a apple' # this may change
 } && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # end of tests

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -157,6 +157,24 @@ printf 'Running tests\n' && {
   assert_true  'false' 'abc' '1' '-12'
   assert_false 'false' 'true' '0'
 
+  # is bool|boolean
+  assert_true 'bool' \
+    0 true 'True' 'TRUE' 't' 'T' 'yes' 'Yes' 'YES' 'y' 'Y' 'on' 'On' 'ON' \
+    1 false 'FALSE' 'False' 'f' 'F' 'no' 'No' 'NO' 'n' 'N' 'off' 'Off' 'OFF'
+  _assert_raises 2 'boolean' 'abc' -1 2
+
+  # # is truthy
+  assert_true 'truthy' \
+    0 true 'True' 'TRUE' 't' 'T' 'yes' 'Yes' 'YES' 'y' 'Y' 'on' 'On' 'ON'
+  assert_false 'truthy' \
+    1 false 'FALSE' 'False' 'f' 'F' 'no' 'No' 'NO' 'n' 'N' 'off' 'Off' 'OFF'
+
+  # # is falsey
+  assert_true 'falsey' \
+    1 false 'FALSE' 'False' 'f' 'F' 'no' 'No' 'NO' 'n' 'N' 'off' 'Off' 'OFF'
+  assert_false 'falsey' \
+    0 true 'True' 'TRUE' 't' 'T' 'yes' 'Yes' 'YES' 'y' 'Y' 'on' 'On' 'ON'
+
   # negation
   assert_true  'not number' 'abc'
   assert_true  'not equal' 'abc def'

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -402,6 +402,10 @@ test::run() {
   assert_true  'available' 'which'
   assert_false 'installed' 'witch'
 
+  # is cmd|command
+  assert_true  'cmd' 'which'
+  assert_false 'command' 'witch'
+
   # is empty
   assert_true  'empty' "$val_string_empty" '""'
   assert_false 'empty' $val_string
@@ -530,10 +534,6 @@ test::run() {
   assert_false 'in' "$needle array_empty" "$needle array_withoutNeedle" \
     "$needle array_withNeedleasSubstring"
     assert_false 'in' 'a apple' # this may change
-
-  # is cmd|command
-  assert_true  'cmd' 'which'
-  assert_false 'command' 'witch'
 }
 
 printf 'Warming Tests\n' \

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -8,11 +8,6 @@ fi
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd -P )
 CMD=$(which "${1:-$DIR/is.sh}")
 
-# shellcheck source=/dev/null
-. "$DIR/tests/assert.sh"
-
-echo Testing \"$CMD\"
-
 # : 1> file === touch file without calling an external tool
 # read -rst # -n 999 === sleep # without calling an external tool
 # Prepare working directory
@@ -45,7 +40,10 @@ assert_false() {
     assert_raises "$1" 1
 }
 
+# shellcheck source=/dev/null
+. "$DIR/tests/assert.sh"
 
+echo Testing \"$CMD\"
 #
 # Tests
 #

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -357,13 +357,13 @@ assert_false() { _assert_raises 1 "${1}" "${@:2}"; }
 # Tests
 test::run() {
   # no args
-  assert_true $val_string_empty
+  assert_true '' "$val_string_empty"
 
   # help
-  assert_true '--help'
+  assert_true '' '--help'
 
   # version
-  assert_true '--version'
+  assert_true '' '--version'
 
   # unspported condition
   assert_false 'spam' 'foo bar'

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -12,10 +12,10 @@ FILE="${1:-"$DIR/is.sh"}"
 # read -rst # -n 999 === sleep # without calling an external tool
 # Prepare working directory
 # shellcheck disable=SC2034
-printf 'Warming tests\n' && {
+test::warm() {
   command cd "$(mktemp -d)" || exit 1
 
-  declare var_declared \
+  declare -g var_declared \
     path_file_inexistent='./file_inexistent' \
     path_file_old='./file_old' \
     path_file_new='./file_new' \
@@ -27,10 +27,10 @@ printf 'Warming tests\n' && {
     path_dir_rel='./dir_rel' \
     path_dir_symlink='dir_symlink'
 
-  declare var_unset=''
+  declare -g var_unset=''
   command unset ${BASH_VERSION+-v} var_unset
 
-  declare string='string' substr='str' not_substr="rts" string_empty=''
+  declare -g string='string' substr='str' not_substr="rts" string_empty=''
 
   : 1> 'file_forbidden'
   chmod 000 'file_forbidden'
@@ -39,18 +39,17 @@ printf 'Warming tests\n' && {
   command read -rst 1 -n 999
   : 1> $path_file_new
 
-  : 1> $path_file_abs
+  : 1> "$path_file_abs"
   : 1> $path_file_rel
   chmod 777 $path_file_rel
-  mkdir $path_dir_rel $path_dir_abs
+  mkdir $path_dir_rel "$path_dir_abs"
   ln -s $path_file_rel $path_file_symlink
   ln -s $path_dir_rel $path_dir_symlink
 
   command alias myAlias=''
 
-  declare bell=$'\a' backspace=$'\b'
-  declare needle=':'
-  declare -a array_empty=() \
+  declare -g bell=$'\a' backspace=$'\b' needle=':'
+  declare -ag array_empty=() \
     array_withNeedle=(':') \
     array_withoutNeedle=('a' '' 0 true) \
     array_withNeedleasSubstring=(
@@ -73,21 +72,21 @@ printf 'Warming tests\n' && {
     truthy=(0 true 'True' 't' 'YES' 'Y' 'on')
 
   # note: `$uint64` evaluates to zero
-  declare uint16=$((2**16)) \
+  declare -g uint16=$((2**16)) \
     uint32=$((2**32)) \
     uint64=$((2**64)) \
     sint64=$((2**63-1))
-  declare nsint64=$((sint64+1))
+  declare -g nsint64=$((sint64+1))
   sint64="+$sint64"
 
-  declare udec16="$uint16.0" \
+  declare -g udec16="$uint16.0" \
     sdec16="+$udec16" \
     nsdec16="-$udec16" \
     rgb='0011ff' \
     udec16_comma="$uint16,0" \
     e_notation="${uint16}e${uint16}" \
     curreny_usd="\$${uint16}"
-} && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
+}
 
 # Helpers
 _assert_raises() {
@@ -98,11 +97,8 @@ _assert_raises() {
 assert_true() { _assert_raises 0 "${1}" "${@:2}"; }
 assert_false() { _assert_raises 1 "${1}" "${@:2}"; }
 
-# shellcheck source=./assert.sh
-. "$DIR/tests/assert.sh"
-
 # Tests
-printf 'Running tests\n' && {
+test::run() {
   # no args
   assert_true $string_empty
 
@@ -261,7 +257,18 @@ printf 'Running tests\n' && {
   # is cmd|command
   assert_true  'cmd' 'which'
   assert_false 'command' 'witch'
-} && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
+}
+
+printf 'Warming Tests\n' \
+  && test::warm \
+  && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
+
+# shellcheck source=./assert.sh
+. "$DIR/tests/assert.sh"
+
+printf 'Running Tests\n' \
+  && test::run \
+  && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # end of tests
 # shellcheck disable=SC2119

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -526,8 +526,8 @@ test::run() {
   assert_false 'function' $ref_alias $ref_builtin $ref_keyword CMD
 
   # is set|var|variable
-  assert_true  'set' 'val_string_empty'
-  assert_false 'var' 'var_declared' 'var_undeclared' 'var_unset'
+  assert_true  'set' val_string_empty
+  assert_false 'var' var_undeclared var_declared var_unset
 
   # is in
   assert_true  'in' "$needle array_withNeedle"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -13,24 +13,25 @@ CMD=$(which "${1:-$DIR/is.sh}")
 
 echo Testing \"$CMD\"
 
-
-#
+# : 1> file === touch file without calling an external tool
+# read -rst # -n 999 === sleep # without calling an external tool
 # Prepare working directory
-#
-
+printf 'Warming tests\n' && {
 cd "$(mktemp -d)" || exit 1
 
-touch file
-chmod 777 file
-touch forbidden_file
-chmod 000 forbidden_file
-touch old_file
-sleep 2
-touch new_file
-mkdir dir
-ln -s file symlink_file
-ln -s dir symlink_dir
+  : 1> 'forbidden_file'
+  chmod 000 'forbidden_file'
 
+  : 1> 'old_file'
+  read -rst 1 -n 999
+  : 1> 'new_file'
+
+  : 1> 'file'
+  chmod 777 'file'
+  mkdir 'dir'
+  ln -s 'file' 'symlink_file'
+  ln -s 'dir' 'symlink_dir'
+} && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 #
 # Helpers

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
-declare DIR CMD
+declare CMD='is' DIR FILE
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
-CMD="${1:-"$DIR/is.sh"}"
+FILE="${1:-"$DIR/is.sh"}"
 
-if [ -n "$FILE" ] && ! which "$FILE" > /dev/null; then
-    printf '%s not found.\n' "$FILE"
-    exit 1
-fi
+# shellcheck source=../is.sh
+. "$FILE"
+! command -v "$CMD" > /dev/null && printf '%s not found.\n' "$CMD" && exit 1
 
 # : 1> file === touch file without calling an external tool
 # read -rst # -n 999 === sleep # without calling an external tool

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -213,4 +213,5 @@ assert_true "$is --help"
 assert_false "$is spam foo bar"
 
 # end of tests
+# shellcheck disable=SC2119
 assert_end

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -9,6 +9,8 @@ FILE="${1:-"$DIR/is.sh"}"
 . "$FILE"
 ! command -v "$CMD" > /dev/null && printf '%s not found.\n' "$CMD" && exit 1
 
+readonly PASS="\033[s\033[1F\033[%s@\033[%s@\033[32m\342\234\223\033[39m\033[u"
+
 # : 1> file === touch file without calling an external tool
 # read -rst # -n 999 === sleep # without calling an external tool
 # Prepare working directory
@@ -359,7 +361,7 @@ printf 'Warming Tests\n' && {
     var_gax
     var_gAx
   )
-} && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
+} && printf "$PASS" '' ''
 
 # Helpers
 _assert_raises() {
@@ -565,9 +567,7 @@ test::run() {
 # shellcheck source=./assert.sh
 . "$DIR/tests/assert.sh"
 
-printf 'Running Tests\n' \
-  && test::run \
-  && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
+printf 'Running Tests\n' && test::run && printf "$PASS" '' ''
 
 # end of tests
 # shellcheck disable=SC2119

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -448,8 +448,9 @@ test::run() {
   # is match|matching
   assert_true  'match' "'[$val_string]+' '$val_string'" \
                        "'[$val_string]+' $val_str"
-  assert_false 'matching' "[$val_string]+ ${val_string^}" \
-                          "[$val_string]+ '$val_rtS'"
+  # Since we currently support bash v3.2.57, we can't use `"${1^}"`
+  assert_false 'matching' "[$val_string]+ '$val_rtS'" \
+    "[$val_string]+ $(printf '%s' "$val_string" | tr '[:lower:]' '[:upper:]')"
 
   # is val_str|substring
   assert_true  'substr' "$val_str $val_string"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -59,8 +59,8 @@ test::warm() {
       "a${needle}"
       ''
     ) \
-    falsey=(1 false 'FALSE' 'F' 'No' 'n' 'OFF') \
-    truthy=(0 true 'True' 't' 'YES' 'Y' 'on')
+    array_falsey=(1 false 'FALSE' 'F' 'No' 'n' 'OFF') \
+    array_truthy=(0 true 'True' 't' 'YES' 'Y' 'on')
 
   # shellcheck disable=SC1010,SC1083
   # We disable these because we are intentionally not quoting these so as to
@@ -460,16 +460,16 @@ test::run() {
   assert_false 'false' 0 true
 
   # is bool|boolean
-  assert_true 'bool' "${truthy[@]}" "${falsey[@]}"
+  assert_true 'bool' "${array_truthy[@]}" "${array_falsey[@]}"
   _assert_raises 2 'boolean' $val_string $val_nsint64 $val_uint16
 
   # # is truthy
-  assert_true 'truthy' "${truthy[@]}"
-  assert_false 'truthy' "${falsey[@]}"
+  assert_true 'truthy' "${array_truthy[@]}"
+  assert_false 'truthy' "${array_falsey[@]}"
 
   # # is falsey
-  assert_true 'falsey' "${falsey[@]}"
-  assert_false 'falsey' "${truthy[@]}"
+  assert_true 'falsey' "${array_falsey[@]}"
+  assert_false 'falsey' "${array_truthy[@]}"
 
   # negation
   assert_true  'not number' $val_string

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -28,6 +28,10 @@ printf 'Warming tests\n' && {
   ln -s 'dir' 'symlink_dir'
 
   command alias myAlias=''
+
+  declare var_declared
+  declare var_initialized='' var_unset=''
+  command unset ${BASH_VERSION+-v} var_unset
 } && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # Helpers
@@ -171,6 +175,10 @@ printf 'Running tests\n' && {
   # is fn|function
   assert_true  'fn' '_assert_raises'
   assert_false 'function' 'CMD'
+
+  # is set|var|variable
+  assert_true  'set' 'var_initialized'
+  assert_false 'var' 'var_declared' 'var_undeclared' 'var_unset'
 } && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # end of tests

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -103,6 +103,18 @@ assert_false() { _assert_raises 1 "${1}" "${@:2}"; }
 
 # Tests
 printf 'Running tests\n' && {
+  # no args
+  assert_true $string_empty
+
+  # help
+  assert_true '--help'
+
+  # version
+  assert_true '--version'
+
+  # unspported condition
+  assert_false 'spam' 'foo bar'
+
   # is file
   assert_true  'file' "$path_file_abs" $path_file_rel $path_file_symlink
   assert_false 'file' $path_dir_rel $path_dir_symlink $path_file_inexistent
@@ -219,18 +231,6 @@ printf 'Running tests\n' && {
   assert_true  'not a number' $string
   assert_true  'not an number' $string
   assert_true  'not the number' $string
-
-  # version
-  assert_true '--version'
-
-  # help
-  assert_true '--help'
-
-  # no args
-  assert_true $string_empty
-
-  # unspported condition
-  assert_false 'spam' 'foo bar'
 
   # is alias
   assert_true  'alias' myAlias

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -26,6 +26,8 @@ printf 'Warming tests\n' && {
   mkdir 'dir'
   ln -s 'file' 'symlink_file'
   ln -s 'dir' 'symlink_dir'
+
+  command alias myAlias=''
 } && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # Helpers
@@ -153,6 +155,22 @@ printf 'Running tests\n' && {
 
   # unknown condition
   assert_false 'spam' 'foo bar'
+
+  # is alias
+  assert_true  'alias' 'myAlias'
+  assert_false 'alias' 'CMD'
+
+  # is builtin
+  assert_true  'builtin' 'printf' 'true'
+  assert_false 'builtin' 'grep'
+
+  # is keyword
+  assert_true  'keyword' 'if' 'while'
+  assert_false 'keyword' 'CMD'
+
+  # is fn|function
+  assert_true  'fn' '_assert_raises'
+  assert_false 'function' 'CMD'
 } && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # end of tests

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -13,13 +13,13 @@ FILE="${1:-"$DIR/is.sh"}"
 # Prepare working directory
 # shellcheck disable=SC2034
 printf 'Warming tests\n' && {
-  cd "$(mktemp -d)" || exit 1
+  command cd "$(mktemp -d)" || exit 1
 
   : 1> 'forbidden_file'
   chmod 000 'forbidden_file'
 
   : 1> 'old_file'
-  read -rst 1 -n 999
+  command read -rst 1 -n 999
   : 1> 'new_file'
 
   : 1> 'file'

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -44,13 +44,9 @@ assert_false() {
 # shellcheck source=./assert.sh
 . "$DIR/tests/assert.sh"
 
-echo Testing \"$CMD\"
-#
 # Tests
-#
-
 is="$CMD"
-
+printf 'Running tests\n' && {
 # is file
 assert_true  "$is file ./file"
 assert_true  "$is file ./symlink_file"
@@ -212,6 +208,7 @@ assert_true "$is --help"
 
 # unknown condition
 assert_false "$is spam foo bar"
+} && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # end of tests
 # shellcheck disable=SC2119

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -15,22 +15,15 @@ FILE="${1:-"$DIR/is.sh"}"
 test::warm() {
   command cd "$(mktemp -d)" || exit 1
 
-  declare -g var_declared \
-    path_file_inexistent='./file_inexistent' \
-    path_file_old='./file_old' \
-    path_file_new='./file_new' \
-    path_file_forbidden='./file_forbidden' \
-    path_file_abs="${PWD}/file_abs" \
-    path_file_rel='./file_rel' \
-    path_file_symlink='file_symlink' \
-    path_dir_abs="${PWD}/dir_abs" \
+  declare -g path_file_abs="${PWD}/file_abs" path_dir_abs="${PWD}/dir_abs" \
     path_dir_rel='./dir_rel' \
-    path_dir_symlink='dir_symlink'
-
-  declare -g var_unset=''
-  command unset ${BASH_VERSION+-v} var_unset
-
-  declare -g val_string='string' val_str='str' val_rtS='rtS' val_string_empty=''
+    path_dir_symlink='dir_symlink' \
+    path_file_forbidden='./file_forbidden' \
+    path_file_inexistent='./file_inexistent' \
+    path_file_new='./file_new' \
+    path_file_old='./file_old' \
+    path_file_rel='./file_rel' \
+    path_file_symlink='file_symlink'
 
   : 1> 'file_forbidden'
   chmod 000 'file_forbidden'
@@ -45,8 +38,6 @@ test::warm() {
   mkdir $path_dir_rel "$path_dir_abs"
   ln -s $path_file_rel $path_file_symlink
   ln -s $path_dir_rel $path_dir_symlink
-
-  command alias myAlias=''
 
   declare -g bell=$'\a' backspace=$'\b' needle=':'
   declare -ag array_empty=() \
@@ -71,20 +62,287 @@ test::warm() {
     falsey=(1 false 'FALSE' 'F' 'No' 'n' 'OFF') \
     truthy=(0 true 'True' 't' 'YES' 'Y' 'on')
 
-  # note: bash's goes up to but excludes uint64 (2**64); it will evaluate to 0
-  declare -g val_uint16=$((2**16)) \
-    val_uint32=$((2**32)) \
-    val_sint64=$((2**63-1))
-  declare -g val_nsint64=$((val_sint64+1))
-  val_sint64="+$val_sint64"
+  # shellcheck disable=SC1010,SC1083
+  # We disable these because we are intentionally not quoting these so as to
+  #   potentially display your editors language syntax highlighting.
+  #   Ideally, these should be highlighted like any other string literal.
 
-  declare -g val_udec16="$val_uint16.0" \
-    val_sdec16="+$val_udec16" \
-    val_nsdec16="-$val_udec16" \
-    val_rgb='0011ff' \
-    val_udec16_comma="$val_uint16,0" \
+  # these are syntactically valid forms
+  declare -a array_keywords_brackets=(
+    '[[' ']]' # these are parsed individually
+    [[ ]] # this is parsed as a single string
+    [[
+
+    ]]
+    [[
+    ]]
+    [[
+      # current bug:
+    ]]
+    [[ # command subsitution gets evaluates in these comments
+
+    ]]
+    [[
+
+    ]]  # so if there is an unbalanced backtick or
+    [[ # then bash will throw an EOF error
+       # this subsequent closing double bracket actually gets parsed as the
+       #    balanced pair and the subsequent one is lone
+       #    but because a lone closing double bracket is a valid keyword, we
+       #    can put it in this array
+       # ]]
+    ]]
+    [[ # ]]
+    ]]
+    [[
+      #
+    ]]
+    # i.e the following two lines are equivalent
+    [[ { "hello" } ]]
+    '[[ { "hello" } ]]'
+    [[
+        # any content, sans comment, between [[ && ]] will be parsed
+        # as a single string, even in this array
+    ]]
+    [[
+      # $()
+    ]]
+    [[
+      # ``
+    ]]
+    [[
+      # $(``)
+    ]]
+    [[
+      # $
+    ]]
+    [[
+      # \`
+    ]]
+    [[
+      # (
+    ]]
+    [[
+      # \`\`
+    ]]
+  )
+  # shellcheck disable=SC1010,SC1083
+  declare -ag array_keywords=(
+    if then elif else fi
+    for in do done
+    while until
+    case esac
+    function
+    select
+    time
+    !
+    "${array_keywords_brackets[@]}"
+  )
+
+  # similar to the keyword [[ (as seen above), test's bracket alias has similar
+  #   issues these are syntactically valid forms
+  # shellcheck disable=SC1010,SC1083
+  declare -a array_builtin_test_bracket=(
+    '[' # these are parsed individually
+    [ ] # this is parsed as a single string
+    [
+
+    ]
+    [
+    ]
+    [
+      # this is valid
+    ]
+    [ # this is valid
+
+    ]
+    [ # this is valid
+       # this is valid
+    ]
+    [
+      #
+    ]
+    # i.e the following two lines are equivalent
+    [ { "hello" } ]
+    '[ { "hello" } ]'
+    [
+        # any content, sans comment, between [ && ] will be parsed
+        # as a single string, even in this array
+    ]
+    [
+      # $()
+    ]
+    [
+      # ``
+    ]
+    [
+      # $(``)
+    ]
+    [
+      # $
+    ]
+    [
+      # \`
+    ]
+    [
+      # (
+    ]
+    [
+      # \`\`
+    ]
+  )
+  declare -ag array_builtins_bash=(
+    alias unalias
+    bind
+    builtin
+    caller
+    command type
+    declare local typeset
+    echo printf
+    enable
+    help
+    let
+    logout
+    mapfile read readarray
+    source # `.` facade
+    ulimit
+    # Job Control Builtins
+    bg fg jobs kill wait disown suspend
+    # Directory Stack Builtins
+    dirs popd pushd
+    # History Builtins
+    fc history
+    # Programmable Completion Builtins
+    compgen complete compopt
+    # Special builtins
+    shopt
+  ) \
+  array_builtins_sh=(
+    true # `:` facade
+    false # `! true` facade
+    cd
+    getopts
+    hash
+    pwd
+    test
+    times
+    umask
+    "${array_builtin_test_bracket[@]}"
+    # Special POSIX builtins
+    :
+    .
+    break
+    continue
+    eval
+    exec
+    exit
+    export
+    readonly
+    return
+    set
+    shift
+    trap
+    unset
+  ) \
+  array_not_builtins=(
+    [] '[]' ]
+    grep sed awk touch
+    "$ref_alias" "$ref_function" "$ref_keyword"
+  )
+
+  #  # These cause a EOF error due to improper parsing of command subsitution
+  #   within comments
+  declare -ag parser_error_for_keyword_double_bracket=(
+    # [[
+    #   # $([[)
+    #   # $(]])
+    #   # `
+    #   # \``
+    #   # `\`
+    #   # $(
+    #   # ]] this text will be considered outside of the brackets
+    #   # [[ this text will be considered outside of the brackets previous
+    #   #   brackets since the line above closes it
+    # ]]
+  ) \
+  parser_error_for_builtin_test_bracket=(
+    # [
+    #   # $([)
+    #   # $(])
+    #   # `
+    #   # \``
+    #   # `\`
+    #   # $(
+    #   # this commented out right square bracket gets parsed as a normal one
+    #   #   it can be located anywhere in between the top & bottom-most brackets
+    #   # [
+    #   # ]
+    # ]
+  )
+
+  declare -g var_declared var_unset=''
+  command unset ${BASH_VERSION+-v} var_unset
+
+  declare -g val_string='string' val_str='str' val_rtS='rtS' val_string_empty=''
+
+  # remember, -g just bring the variables scope to the top
+  #   `declare -p` will not show `-g`
+  declare -gi var_gi=0
+  declare -ga var_ga=([0]='-ga')
+  declare -gA var_gA=([0]='-gA')
+  declare -gx var_gx='-x'
+
+  # -{i,a,A}gx, -{i,a,A}xg, -gx{i,a,A}, -x{i,a,A}g, -xg{i,a,A},
+  #   will all evaluate to -g{i,a,A}x
+  #   likewise with -g{i,a,A}, -{i,a,A}g and then exporting
+  declare -gix var_gix=1
+  declare -gax var_gax=([0]='-gax')
+  declare -gAx var_gAx=([0]='-gAx')
+
+  command alias myAlias=''
+  declare -g ref_alias='myAlias' \
+    ref_builtin='printf' \
+    ref_keyword='if' \
+    ref_function='assert_true' \
+    ref_var_gi='var_gi'
+
+  # note: bash's goes up to but excludes uint64 (2**64); it will evaluate to 0
+  declare -g val_uint16=$((2**16)) val_uint32=$((2**32)) val_sint64=$((2**63-1))
+  declare -g val_nsint64=$((val_sint64+1)) # wraps to negative
+  val_sint64="+$val_sint64"
+  declare -g val_udec16dot0="$val_uint16.0"
+    val_udec16dot16="$val_uint16.$val_uint16"
+
+  declare -g val_rgb='0011ff' \
+    val_curreny_usd="'\$$val_uint16'" \
     val_e_notation="${val_uint16}e${val_uint16}" \
-    val_curreny_usd="\$${val_uint16}"
+    val_nsdec16="-$val_udec16dot0" \
+    val_sdec16="+$val_udec16dot0" \
+    val_udec16comma0="$val_uint16,0"
+
+  declare -ga array_decimal=(
+    "$val_nsdec16"
+    "$val_sdec16"
+    "$val_udec16dot0"
+    "$val_udec16dot16"
+  ) \
+  array_int=(
+    "$ref_var_gi" var_gi var_gix
+    "$val_nsint64"
+    "$val_sint64"
+    "$val_uint16"
+  ) \
+  array_not_int=(
+    "+$val_nsint64"
+    "$val_curreny_usd"
+    "$val_e_notation"
+    "$val_rgb"
+    "$val_string_empty"
+    "$val_string"
+    "$val_udec16comma0"
+    var_gax
+    var_gAx
+  )
 }
 
 # Helpers
@@ -148,10 +406,6 @@ test::run() {
   assert_true  'empty' "$val_string_empty" '""'
   assert_false 'empty' $val_string
 
-  # is number
-  assert_true  'number' $val_uint16 "$val_uint16.$val_uint16" $val_sint64 $val_nsint64 $val_curreny_usd
-  assert_false 'number' $val_string $val_rgb $val_udec16_comma $val_e_notation "+$val_nsint64"
-
   # is older
   assert_true  'older' "$path_file_old $path_file_new"
   assert_false 'older' "$path_file_new $path_file_old"
@@ -161,31 +415,31 @@ test::run() {
   assert_true  'newer' "$path_file_new $path_file_old"
 
   # is gt
-  assert_true  'gt' "$val_uint32 $val_udec16" "$val_uint32 $val_uint16"
+  assert_true  'gt' "$val_uint32 $val_udec16dot0" "$val_uint32 $val_uint16"
   assert_false 'gt' "$val_uint16 $val_string" "$val_string $val_uint16" \
-                    "$val_uint16 $val_udec16" "$val_udec16 $val_uint32" \
+                    "$val_uint16 $val_udec16dot0" "$val_udec16dot0 $val_uint32" \
                     "$val_string $val_string"
 
   # is lt
-  assert_true  'lt' "$val_udec16 $val_uint32" "$val_uint16 $val_uint32"
+  assert_true  'lt' "$val_udec16dot0 $val_uint32" "$val_uint16 $val_uint32"
   assert_false 'lt' "$val_uint16 $val_string" "$val_string $val_uint16" \
-                    "$val_uint16 $val_udec16" "$val_uint32 $val_udec16" \
+                    "$val_uint16 $val_udec16dot0" "$val_uint32 $val_udec16dot0" \
                     "$val_string $val_string"
 
   # is ge
-  assert_true  'ge' "$val_uint32 $val_udec16" "$val_uint16 $val_udec16"
+  assert_true  'ge' "$val_uint32 $val_udec16dot0" "$val_uint16 $val_udec16dot0"
   assert_false 'ge' "$val_uint16 $val_string" "$val_string $val_uint16" \
-                    "$val_udec16 $val_uint32" "$val_string $val_string"
+                    "$val_udec16dot0 $val_uint32" "$val_string $val_string"
 
   # is le
-  assert_true  'le' "$val_udec16 $val_uint32" "$val_uint16 $val_udec16"
+  assert_true  'le' "$val_udec16dot0 $val_uint32" "$val_uint16 $val_udec16dot0"
   assert_false 'le' "$val_uint16 $val_string" "$val_string $val_uint16" \
-                    "$val_uint32 $val_udec16" "$val_string $val_string"
+                    "$val_uint32 $val_udec16dot0" "$val_string $val_string"
 
   # is eq|equal
-  assert_true  'eq' "$val_string $val_string" "$val_uint16 $val_udec16"
-  assert_false 'equal' "$val_uint16 $val_string" "$val_string $val_uint16" \
-                       "$val_udec16 $val_uint32" "$val_uint32 $val_udec16"
+  assert_true  'equal' "$val_string $val_string" "$val_uint16 $val_udec16dot0"
+  assert_false 'eq' "$val_uint16 $val_string" "$val_string $val_uint16" \
+                    "$val_udec16dot0 $val_uint32" "$val_uint32 $val_udec16dot0"
 
   # is match|matching
   assert_true  'match' "'[$val_string]+' '$val_string'" \
@@ -231,21 +485,41 @@ test::run() {
   assert_true  'not an number' $val_string
   assert_true  'not the number' $val_string
 
+  # is number
+  assert_true  'number' "${array_int[@]}" "${array_decimal[@]}"
+  assert_false 'num' "${array_not_int[@]}"
+
+  # is int
+  assert_true  'integer' "${array_int[@]}"
+  assert_false 'integer' "${array_not_int[@]}" "${array_decimal[@]}"
+
+  # is array
+  assert_true  'array' var_ga var_gax
+  assert_false 'array' var_gx var_gA var_gAx
+
+  # is hash
+  assert_true  'hash' var_gA var_gAx
+  assert_false 'dictionary' var_gx var_ga var_gaX
+
+  # is export
+  assert_true  'export' var_gx var_gax var_gix var_gAx
+  assert_false 'exported' var_gA var_ga var_gi
+
   # is alias
-  assert_true  'alias' myAlias
-  assert_false 'alias' "\$CMD"
+  assert_true  'alias' $ref_alias
+  assert_false 'alias' $ref_builtin $ref_function $ref_keyword "\$CMD"
 
   # is builtin
-  assert_true  'builtin' printf true
-  assert_false 'builtin' grep
+  assert_true  'builtin' "${array_builtins_sh[@]}" "${array_builtins_bash[@]}"
+  assert_false 'builtin' "${array_not_builtins[@]}"
 
   # is keyword
-  assert_true  'keyword' if while
-  assert_false 'keyword' 'CMD'
+  assert_true  'keyword' $ref_keyword
+  assert_false 'keyword' $ref_alias $ref_builtin $ref_function CMD
 
-  # is fn|function
-  assert_true  'fn' '_assert_raises'
-  assert_false 'function' 'CMD'
+  # is function
+  assert_true  'fn' $ref_function
+  assert_false 'function' $ref_alias $ref_builtin $ref_keyword CMD
 
   # is set|var|variable
   assert_true  'set' 'val_string_empty'
@@ -275,4 +549,4 @@ printf 'Running Tests\n' \
 
 # end of tests
 # shellcheck disable=SC2119
-assert_end
+assert_end "${CMD}"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -91,7 +91,7 @@ printf 'Warming tests\n' && {
 
 # Helpers
 _assert_raises() {
-  local args expected=$1 condition=$2 && shift 2
+  local args expected="${1-}" condition="${2-}" && shift 2
   for args in "${@}"; do assert_raises "$CMD $condition $args" "$expected"; done
 }
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -11,6 +11,7 @@ FILE="${1:-"$DIR/is.sh"}"
 # : 1> file === touch file without calling an external tool
 # read -rst # -n 999 === sleep # without calling an external tool
 # Prepare working directory
+# shellcheck disable=SC2034
 printf 'Warming tests\n' && {
   cd "$(mktemp -d)" || exit 1
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -46,17 +46,19 @@ printf 'Running tests\n' && {
   assert_true  'file' './file' './symlink_file'
   assert_false 'file' './dir' './symlink_dir' './nothing'
 
-  # is directory
-  assert_true  'directory' './dir' './symlink_dir'
+  # is dir|directory
+  assert_true  'dir' './dir' './symlink_dir'
   assert_false 'directory' './file' './symlink_file' './nothing'
 
-  # is link
+  # is link|symlink
   assert_false 'link' './file' './dir' './nothing'
-  assert_true  'link' './symlink_file' './symlink_dir'
+  assert_true  'symlink' './symlink_file' './symlink_dir'
 
-  # is existent
+  # is existent|exist|exists|existing
   assert_true  'existent' './file' './symlink_file' './dir' './symlink_dir'
-  assert_false 'existent' './nothing'
+  assert_true  'exist' './file'
+  assert_true  'exists' './file'
+  assert_false 'existing' './nothing'
 
   # is writable
   assert_true  'writeable' './file'
@@ -70,9 +72,9 @@ printf 'Running tests\n' && {
   assert_true  'executable' './file'
   assert_false 'executable' './forbidden_file'
 
-  # is available
+  # is available|installed
   assert_true  'available' 'which'
-  assert_false 'available' 'witch'
+  assert_false 'installed' 'witch'
 
   # is empty
   assert_true  'empty' '' '""'
@@ -106,16 +108,16 @@ printf 'Running tests\n' && {
   assert_true  'le' '111 222.0' '222 222.0'
   assert_false 'le' '333 222.0' 'abc 222' '222 abc' 'abc abc'
 
-  # is equal
-  assert_true  'equal' 'abc abc' '222 222.0'
+  # is eq|equal
+  assert_true  'eq' 'abc abc' '222 222.0'
   assert_false 'equal' '333 222.0' '111 222.0' 'abc 222' '222 abc'
 
-  # is matching
-  assert_true  'matching' '"[a-c]+" "abc"'
+  # is match|matching
+  assert_true  'match' '"[a-c]+" "abc"'
   assert_false 'matching' '"[a-c]+" "Abc"' '"[a-c]+" "abd"'
 
-  # is substring
-  assert_true  'substring' 'cde abcdef'
+  # is substr|substring
+  assert_true  'substr' 'cde abcdef'
   assert_false 'substring' 'cdf abcdef'
 
   # is true
@@ -139,17 +141,6 @@ printf 'Running tests\n' && {
   assert_true  'not a number' 'abc'
   assert_true  'not an number' 'abc'
   assert_true  'not the number' 'abc'
-
-  # test aliases
-  assert_true  'dir' './dir'
-  assert_true  'symlink' './symlink_file'
-  assert_true  'existing' './file'
-  assert_true  'exist' './file'
-  assert_true  'exists' './file'
-  assert_true  'eq' '222 222.0'
-  assert_true  'match' '"^[a-c]+$" "abc"'
-  assert_true  'substr' 'cde abcdef'
-  assert_true  'installed' 'which'
 
   # --version
   assert_true '--version'

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -12,7 +12,7 @@ FILE="${1:-"$DIR/is.sh"}"
 # read -rst # -n 999 === sleep # without calling an external tool
 # Prepare working directory
 printf 'Warming tests\n' && {
-cd "$(mktemp -d)" || exit 1
+  cd "$(mktemp -d)" || exit 1
 
   : 1> 'forbidden_file'
   chmod 000 'forbidden_file'
@@ -28,185 +28,137 @@ cd "$(mktemp -d)" || exit 1
   ln -s 'dir' 'symlink_dir'
 } && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
-#
 # Helpers
-#
-
-assert_true() {
-    assert_raises "$1" 0
+_assert_raises() {
+  local args expected=$1 condition=$2 && shift 2
+  for args in "${@}"; do assert_raises "$CMD $condition $args" "$expected"; done
 }
 
-assert_false() {
-    assert_raises "$1" 1
-}
+assert_true() { _assert_raises 0 "${1}" "${@:2}"; }
+assert_false() { _assert_raises 1 "${1}" "${@:2}"; }
 
 # shellcheck source=./assert.sh
 . "$DIR/tests/assert.sh"
 
 # Tests
-is="$CMD"
 printf 'Running tests\n' && {
-# is file
-assert_true  "$is file ./file"
-assert_true  "$is file ./symlink_file"
-assert_false "$is file ./dir"
-assert_false "$is file ./symlink_dir"
-assert_false "$is file ./nothing"
+  # is file
+  assert_true  'file' './file' './symlink_file'
+  assert_false 'file' './dir' './symlink_dir' './nothing'
 
-# is directory
-assert_false "$is directory ./file"
-assert_false "$is directory ./symlink_file"
-assert_true  "$is directory ./dir"
-assert_true  "$is directory ./symlink_dir"
-assert_false "$is directory ./nothing"
+  # is directory
+  assert_true  'directory' './dir' './symlink_dir'
+  assert_false 'directory' './file' './symlink_file' './nothing'
 
-# is link
-assert_false "$is link ./file"
-assert_true  "$is link ./symlink_file"
-assert_false "$is link ./dir"
-assert_true  "$is link ./symlink_dir"
-assert_false "$is link ./nothing"
+  # is link
+  assert_false 'link' './file' './dir' './nothing'
+  assert_true  'link' './symlink_file' './symlink_dir'
 
-# is existent
-assert_true  "$is existent ./file"
-assert_true  "$is existent ./symlink_file"
-assert_true  "$is existent ./dir"
-assert_true  "$is existent ./symlink_dir"
-assert_false "$is existent ./nothing"
+  # is existent
+  assert_true  'existent' './file' './symlink_file' './dir' './symlink_dir'
+  assert_false 'existent' './nothing'
 
-# is writable
-assert_true  "$is writeable ./file"
-assert_false "$is writeable ./forbidden_file"
+  # is writable
+  assert_true  'writeable' './file'
+  assert_false 'writeable' './forbidden_file'
 
-# is readable
-assert_true  "$is readable ./file"
-assert_false "$is readable ./forbidden_file"
+  # is readable
+  assert_true  'readable' './file'
+  assert_false 'readable' './forbidden_file'
 
-# is executable
-assert_true  "$is executable ./file"
-assert_false "$is executable ./forbidden_file"
+  # is executable
+  assert_true  'executable' './file'
+  assert_false 'executable' './forbidden_file'
 
-# is available
-assert_true  "$is available which"
-assert_false "$is available witch"
+  # is available
+  assert_true  'available' 'which'
+  assert_false 'available' 'witch'
 
-# is empty
-assert_true  "$is empty"
-assert_true  "$is empty ''"
-assert_false "$is empty abc"
+  # is empty
+  assert_true  'empty' '' '""'
+  assert_false 'empty' 'abc'
 
-# is number
-assert_true  "$is number 123"
-assert_true  "$is number 123.456"
-assert_false "$is number abc"
-assert_false "$is number 123ff"
-assert_false "$is number 123,456"
-assert_false "$is number 12e3"
+  # is number
+  assert_true  'number' '123' '123.456' '-123' '+123'
+  assert_false 'number' 'abc' '123ff' '123,456' '12e3' '+-123'
 
-# is older
-assert_true  "$is older ./old_file ./new_file"
-assert_false "$is older ./new_file ./old_file"
+  # is older
+  assert_true  'older' './old_file ./new_file'
+  assert_false 'older' './new_file ./old_file'
 
-# is newer
-assert_false "$is newer ./old_file ./new_file"
-assert_true  "$is newer ./new_file ./old_file"
+  # is newer
+  assert_false 'newer' './old_file ./new_file'
+  assert_true  'newer' './new_file ./old_file'
 
-# is gt
-assert_false "$is gt 111 222.0"
-assert_false "$is gt 222 222.0"
-assert_true  "$is gt 333 222.0"
-assert_false "$is gt abc 222"
-assert_false "$is gt 222 abc"
-assert_false "$is gt abc abc"
+  # is gt
+  assert_true  'gt' '333 222.0'
+  assert_false 'gt' '222 222.0' '111 222.0' 'abc 222' '222 abc' 'abc abc'
 
-# is lt
-assert_true  "$is lt 111 222.0"
-assert_false "$is lt 222 222.0"
-assert_false "$is lt 333 222.0"
-assert_false "$is lt abc 222"
-assert_false "$is lt 222 abc"
-assert_false "$is lt abc abc"
+  # is lt
+  assert_true  'lt' '111 222.0'
+  assert_false 'lt' '222 222.0' '333 222.0' 'abc 222' '222 abc' 'abc abc'
 
-# is ge
-assert_false "$is ge 111 222.0"
-assert_true  "$is ge 222 222.0"
-assert_true  "$is ge 333 222.0"
-assert_false "$is ge abc 222"
-assert_false "$is ge 222 abc"
-assert_false "$is ge abc abc"
+  # is ge
+  assert_true  'ge' '333 222.0' '222 222.0'
+  assert_false 'ge' '111 222.0' 'abc 222' '222 abc' 'abc abc'
 
-# is le
-assert_true  "$is le 111 222.0"
-assert_true  "$is le 222 222.0"
-assert_false "$is le 333 222.0"
-assert_false "$is le abc 222"
-assert_false "$is le 222 abc"
-assert_false "$is le abc abc"
+  # is le
+  assert_true  'le' '111 222.0' '222 222.0'
+  assert_false 'le' '333 222.0' 'abc 222' '222 abc' 'abc abc'
 
-# is equal
-assert_false "$is equal 111 222.0"
-assert_true  "$is equal 222 222.0"
-assert_false "$is equal 333 222.0"
-assert_false "$is equal abc 222"
-assert_false "$is equal 222 abc"
-assert_true  "$is equal abc abc"
+  # is equal
+  assert_true  'equal' 'abc abc' '222 222.0'
+  assert_false 'equal' '333 222.0' '111 222.0' 'abc 222' '222 abc'
 
-# is matching
-assert_true  "$is matching '[a-c]+' 'abc'"
-assert_false "$is matching '[a-c]+' 'Abc'"
-assert_false "$is matching '[a-c]+' 'abd"
+  # is matching
+  assert_true  'matching' '"[a-c]+" "abc"'
+  assert_false 'matching' '"[a-c]+" "Abc"' '"[a-c]+" "abd"'
 
-# is substring
-assert_true  "$is substring cde abcdef"
-assert_false "$is substring cdf abcdef"
+  # is substring
+  assert_true  'substring' 'cde abcdef'
+  assert_false 'substring' 'cdf abcdef'
 
-# is true
-assert_false "$is true abc"
-assert_true  "$is true true"
-assert_true  "$is true 0"
-assert_false "$is true 1"
-assert_false "$is true -12"
+  # is true
+  assert_true  'true' 'true' '0'
+  assert_false 'true' 'abc' '1' '-12'
 
-# is false
-assert_true  "$is false abc"
-assert_false "$is false true"
-assert_false "$is false 0"
-assert_true  "$is false 1"
-assert_true  "$is false -12"
+  # is false
+  assert_true  'false' 'abc' '1' '-12'
+  assert_false 'false' 'true' '0'
 
-# negation
-assert_true  "$is not number abc"
-assert_false "$is not number 123"
-assert_true  "$is not equal abc def"
-assert_false "$is not equal abc abc"
+  # negation
+  assert_true  'not number' 'abc'
+  assert_true  'not equal' 'abc def'
+  assert_false 'not number' '123'
+  assert_false 'not equal' 'abc abc'
 
-# articles
-assert_true  "$is a number 123"
-assert_true  "$is an number 123"
-assert_true  "$is the number 123"
-assert_true  "$is not a number abc"
-assert_true  "$is not an number abc"
-assert_true  "$is not the number abc"
+  # articles
+  assert_true  'a number' '123'
+  assert_true  'an number' '123'
+  assert_true  'the number' '123'
+  assert_true  'not a number' 'abc'
+  assert_true  'not an number' 'abc'
+  assert_true  'not the number' 'abc'
 
-# test aliases
-assert_true  "$is dir ./dir"
-assert_true  "$is symlink ./symlink_file"
-assert_true  "$is existing ./file"
-assert_true  "$is exist ./file"
-assert_true  "$is exists ./file"
-assert_true  "$is eq 222 222.0"
-assert_true  "$is match '^[a-c]+$' 'abc'"
-assert_true  "$is substr cde abcdef"
-assert_true  "$is installed which"
+  # test aliases
+  assert_true  'dir' './dir'
+  assert_true  'symlink' './symlink_file'
+  assert_true  'existing' './file'
+  assert_true  'exist' './file'
+  assert_true  'exists' './file'
+  assert_true  'eq' '222 222.0'
+  assert_true  'match' '"^[a-c]+$" "abc"'
+  assert_true  'substr' 'cde abcdef'
+  assert_true  'installed' 'which'
 
-# --version
-assert_true "$is --version"
+  # --version
+  assert_true '--version'
 
-# help
-assert_true "$is --help"
+  # help
+  assert_true '--help'
 
-# unknown condition
-assert_false "$is spam foo bar"
+  # unknown condition
+  assert_false 'spam' 'foo bar'
 } && printf '\033[s\033[1F\033[%s@\033[%s@\033[32m\u2713\033[39m\033[u' '' ''
 
 # end of tests


### PR DESCRIPTION
# Note

I kept `cmd|command` separate from `available|installed` for two reasons:

- to not break backward compatibility
- because really determining if a command is available, installed, or is just
  command, is more complicated; see [has](https://github.com/kdabir/has)

I intended for these changes to be separate PR's but I got caught up and it got
  a little too tedious to re-structure the commits.

Since this doesn't break backwards compatibility, I've updated the version from `1.1.2` -> `1.2.0`

# Changes

- features
  - options:
    - no args will display `--version` followed by `--help`
  - conditions
    - `alias`, `builtin`, `keyword`, `function|fn`, `int|integer`,
      `array`, `hash|dictionary`, `export|exported`
    - `bool|boolean`, `truthy`, `falsey`
    - `cmd|command`
    - `in`
    - `set|var|variable`
  - `.editorconfig`, `.gitignore`
  - test
    - can now be passed in multiple arguments to test against the same condition

- maintainability
  - `version` & `help` are in their own function
    - `printf` over `heredoc` + `cat`
  - reused logic for several conditions
  - `printf` over `echo`
    - `echo` doesn't consistently behave the same across all systems
  - use builtin/internal functionality from bash over external tools
    - since this tool doesn't check dependencies, it'll be _safer_
  - removed duplicate codes

- style
  - spacing: 4 -> 2
  - `printf` over `heredoc` to not have tabs or un-indented code
  - `assert.sh`: move code continuation so syntax highlighting in VSCode doesn't
    mis-color the rest of the file

In the tests file, I kept reference to a bash bug I encountered when parsing the `keyword` & `builtin`, `[[]]` & `[]`, respectively. I can add a note about what version this was found in.